### PR TITLE
Fix unwanted UNIQUE constraints

### DIFF
--- a/etc/ci_settings.xml
+++ b/etc/ci_settings.xml
@@ -5,7 +5,7 @@
         <profile>
             <id>inject-version-variable</id>
             <properties>
-                <app-version>0.0.8</app-version>
+                <app-version>0.0.9</app-version>
             </properties>
         </profile>
     </profiles>

--- a/training-persistence/src/main/resources/db/migration/training/V1.0.0__Trainings_schema.sql
+++ b/training-persistence/src/main/resources/db/migration/training/V1.0.0__Trainings_schema.sql
@@ -60,7 +60,7 @@ CREATE TABLE training_instance (
 );
 
 CREATE TABLE training_instance_user_ref (
-    training_instance_id int8 NOT NULL UNIQUE,
+    training_instance_id int8 NOT NULL,
     user_ref_id          int8 NOT NULL,
     PRIMARY KEY (training_instance_id, user_ref_id),
     FOREIGN KEY (training_instance_id) REFERENCES training_instance,
@@ -181,7 +181,7 @@ CREATE TABLE attachment (
 
 CREATE TABLE training_run_acquisition_lock (
     id                   bigserial NOT NULL,
-    participant_ref_id   bigserial NOT NULL UNIQUE,
+    participant_ref_id   bigserial NOT NULL,
     training_instance_id bigserial NOT NULL,
     creation_time        timestamp NOT NULL,
     PRIMARY KEY (id),


### PR DESCRIPTION
#26 

The instance - user binding table had instance unique, meaning each instance could have max 1 user editing it

I've observed similar inconsistency on training run lock