### PR TITLE
Fix null exception

### DIFF
--- a/etc/ci_settings.xml
+++ b/etc/ci_settings.xml
@@ -5,7 +5,7 @@
         <profile>
             <id>inject-version-variable</id>
             <properties>
-                <app-version>1.2.1</app-version>
+                <app-version>1.2.2</app-version>
             </properties>
         </profile>
     </profiles>

--- a/training-service/src/main/java/cz/cyberrange/platform/training/service/facade/visualization/VisualizationFacade.java
+++ b/training-service/src/main/java/cz/cyberrange/platform/training/service/facade/visualization/VisualizationFacade.java
@@ -549,10 +549,13 @@ public class VisualizationFacade {
           elasticsearchApiService.getAggregatedEventsByLevelsAndTrainingRuns(
               trainingInstance.getId());
       for (AbstractLevel level : levels) {
-        trainingData
-            .events
-            .computeIfAbsent(level.getId(), value -> new HashMap<>())
-            .putAll(instanceEvents.get(level.getId()));
+        Map<Long, List<AbstractAuditPOJO>> levelEvents = instanceEvents.get(level.getId());
+        if (levelEvents != null) {
+          trainingData
+              .events
+              .computeIfAbsent(level.getId(), value -> new HashMap<>())
+              .putAll(levelEvents);
+        }
       }
 
       trainingData.participantsByTrainingRuns.putAll(
@@ -1054,7 +1057,8 @@ public class VisualizationFacade {
     return trainingInstanceData;
   }
 
-  private Map<Long, UserRefDTO> getUserRefDTOsFromInstanceEvents(
+  private Map<Long, UserRefDTO>
+  getUserRefDTOsFromInstanceEvents(
       Long trainingInstanceId,
       Map<Long, Map<Long, List<AbstractAuditPOJO>>> trainingInstanceEvents,
       Function<Map<Long, Map<Long, List<AbstractAuditPOJO>>>, Set<Long>>
@@ -1113,7 +1117,7 @@ public class VisualizationFacade {
     for (AbstractLevel abstractLevel : levels) {
       List<AbstractAuditPOJO> levelEvents = userEvents.getValue().get(abstractLevel.getId());
       if (levelEvents == null) {
-        break;
+        continue;
       }
       ProcessedEventsData processedEventsData =
           getProcessedEventsData(abstractLevel.getOrder(), levelEvents);


### PR DESCRIPTION
Prevent calling put all with null value if no training events are present for a level.

When a trainee has no events for a level, the returned object that is supposed to hold event data was null. Trying to put this object into a Map<> was causing an error.