### PR TITLE
Add `callSuper=true`

### DIFF
--- a/etc/ci_settings.xml
+++ b/etc/ci_settings.xml
@@ -5,7 +5,7 @@
         <profile>
             <id>inject-version-variable</id>
             <properties>
-                <app-version>1.4.2</app-version>
+                <app-version>1.4.3</app-version>
             </properties>
         </profile>
     </profiles>

--- a/training-api/src/main/java/cz/cyberrange/platform/training/api/dto/cheatingdetection/AnswerSimilarityDetectionEventDTO.java
+++ b/training-api/src/main/java/cz/cyberrange/platform/training/api/dto/cheatingdetection/AnswerSimilarityDetectionEventDTO.java
@@ -10,11 +10,17 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@EqualsAndHashCode
-@ApiModel(value = "AnswerSimilarityDetectionEventDTO", description = "A detection event of type Answer Similarity.", parent = AbstractDetectionEventDTO.class)
+@EqualsAndHashCode(callSuper = true)
+@ApiModel(
+    value = "AnswerSimilarityDetectionEventDTO",
+    description = "A detection event of type Answer Similarity.",
+    parent = AbstractDetectionEventDTO.class)
 public class AnswerSimilarityDetectionEventDTO extends AbstractDetectionEventDTO {
-    @ApiModelProperty(value = "Correct answer to the level.", example = "pass")
-    private String answer;
-    @ApiModelProperty(value = "Name of a player who was assigned the correct answer.", example = "John Doe")
-    private String answerOwner;
+  @ApiModelProperty(value = "Correct answer to the level.", example = "pass")
+  private String answer;
+
+  @ApiModelProperty(
+      value = "Name of a player who was assigned the correct answer.",
+      example = "John Doe")
+  private String answerOwner;
 }

--- a/training-api/src/main/java/cz/cyberrange/platform/training/api/dto/cheatingdetection/LocationSimilarityDetectionEventDTO.java
+++ b/training-api/src/main/java/cz/cyberrange/platform/training/api/dto/cheatingdetection/LocationSimilarityDetectionEventDTO.java
@@ -10,14 +10,19 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@EqualsAndHashCode
-@ApiModel(value = "LocationSimilarityDetectionEventDTO", description = "A detection event of type Location Similarity.", parent = AbstractDetectionEventDTO.class)
+@EqualsAndHashCode(callSuper = true)
+@ApiModel(
+    value = "LocationSimilarityDetectionEventDTO",
+    description = "A detection event of type Location Similarity.",
+    parent = AbstractDetectionEventDTO.class)
 public class LocationSimilarityDetectionEventDTO extends AbstractDetectionEventDTO {
 
-    @ApiModelProperty(value = "Ip address of participant.", example = "1.1.1.1")
-    private String ipAddress;
-    @ApiModelProperty(value = "DNS of participant.", example = "dns.provider.cz")
-    private String dns;
-    @ApiModelProperty(value = "If the address is the same as deployment.", example = "false")
-    private boolean isAddressDeploy;
+  @ApiModelProperty(value = "Ip address of participant.", example = "1.1.1.1")
+  private String ipAddress;
+
+  @ApiModelProperty(value = "DNS of participant.", example = "dns.provider.cz")
+  private String dns;
+
+  @ApiModelProperty(value = "If the address is the same as deployment.", example = "false")
+  private boolean isAddressDeploy;
 }

--- a/training-api/src/main/java/cz/cyberrange/platform/training/api/dto/cheatingdetection/MinimalSolveTimeDetectionEventDTO.java
+++ b/training-api/src/main/java/cz/cyberrange/platform/training/api/dto/cheatingdetection/MinimalSolveTimeDetectionEventDTO.java
@@ -10,10 +10,13 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@EqualsAndHashCode
-@ApiModel(value = "MinimalSolveTimeDetectionEventDTO", description = "A detection event of type Minimal Solve Time.", parent = AbstractDetectionEventDTO.class)
+@EqualsAndHashCode(callSuper = true)
+@ApiModel(
+    value = "MinimalSolveTimeDetectionEventDTO",
+    description = "A detection event of type Minimal Solve Time.",
+    parent = AbstractDetectionEventDTO.class)
 public class MinimalSolveTimeDetectionEventDTO extends AbstractDetectionEventDTO {
 
-    @ApiModelProperty(value = "Minimal time required to solve the level.", example = "1")
-    private Long minimalSolveTime;
+  @ApiModelProperty(value = "Minimal time required to solve the level.", example = "1")
+  private Long minimalSolveTime;
 }

--- a/training-api/src/main/java/cz/cyberrange/platform/training/api/dto/cheatingdetection/NoCommandsDetectionEventDTO.java
+++ b/training-api/src/main/java/cz/cyberrange/platform/training/api/dto/cheatingdetection/NoCommandsDetectionEventDTO.java
@@ -1,12 +1,11 @@
 package cz.cyberrange.platform.training.api.dto.cheatingdetection;
 
 import io.swagger.annotations.ApiModel;
-import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 @ToString
-@EqualsAndHashCode
-@ApiModel(value = "NoCommandsDetectionEventDTO", description = "A detection event of type No Commands.", parent = AbstractDetectionEventDTO.class)
-public class NoCommandsDetectionEventDTO extends AbstractDetectionEventDTO {
-
-}
+@ApiModel(
+    value = "NoCommandsDetectionEventDTO",
+    description = "A detection event of type No Commands.",
+    parent = AbstractDetectionEventDTO.class)
+public class NoCommandsDetectionEventDTO extends AbstractDetectionEventDTO {}

--- a/training-api/src/main/java/cz/cyberrange/platform/training/api/dto/hint/TakenHintDTO.java
+++ b/training-api/src/main/java/cz/cyberrange/platform/training/api/dto/hint/TakenHintDTO.java
@@ -2,118 +2,110 @@ package cz.cyberrange.platform.training.api.dto.hint;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
-import java.util.Objects;
-
-/**
- * Encapsulates information about hint that was already taken
- */
-@EqualsAndHashCode
+/** Encapsulates information about hint that was already taken */
 @Getter
 @Setter
 @ToString
-@ApiModel(value = "TakenHintDTO", description = "A taken brief textual description to aid the participant.")
+@ApiModel(
+    value = "TakenHintDTO",
+    description = "A taken brief textual description to aid the participant.")
 public class TakenHintDTO {
 
-    @ApiModelProperty(value = "Main identifier of hint.", example = "1")
-    private Long id;
-    @ApiModelProperty(value = "Short textual description of the hint.", example = "Hint1")
-    private String title;
-    @ApiModelProperty(value = "The information and experiences that are directed towards a participant.", example = "Very good advice")
-    private String content;
-    @ApiModelProperty(value = "The order of hint in training level", example = "1")
-    private int order;
+  @ApiModelProperty(value = "Main identifier of hint.", example = "1")
+  private Long id;
 
-    /**
-     * Gets id.
-     *
-     * @return the id
-     */
-    public Long getId() {
-        return id;
-    }
+  @ApiModelProperty(value = "Short textual description of the hint.", example = "Hint1")
+  private String title;
 
-    /**
-     * Sets id.
-     *
-     * @param id the id
-     */
-    public void setId(Long id) {
-        this.id = id;
-    }
+  @ApiModelProperty(
+      value = "The information and experiences that are directed towards a participant.",
+      example = "Very good advice")
+  private String content;
 
-    /**
-     * Gets title.
-     *
-     * @return the title
-     */
-    public String getTitle() {
-        return title;
-    }
+  @ApiModelProperty(value = "The order of hint in training level", example = "1")
+  private int order;
 
-    /**
-     * Sets title.
-     *
-     * @param title the title
-     */
-    public void setTitle(String title) {
-        this.title = title;
-    }
+  /**
+   * Gets id.
+   *
+   * @return the id
+   */
+  public Long getId() {
+    return id;
+  }
 
-    /**
-     * Gets content.
-     *
-     * @return the content
-     */
-    public String getContent() {
-        return content;
-    }
+  /**
+   * Sets id.
+   *
+   * @param id the id
+   */
+  public void setId(Long id) {
+    this.id = id;
+  }
 
-    /**
-     * Sets content.
-     *
-     * @param content the content
-     */
-    public void setContent(String content) {
-        this.content = content;
-    }
+  /**
+   * Gets title.
+   *
+   * @return the title
+   */
+  public String getTitle() {
+    return title;
+  }
 
-    public int getOrder() {
-        return order;
-    }
+  /**
+   * Sets title.
+   *
+   * @param title the title
+   */
+  public void setTitle(String title) {
+    this.title = title;
+  }
 
-    public void setOrder(int order) {
-        this.order = order;
-    }
+  /**
+   * Gets content.
+   *
+   * @return the content
+   */
+  public String getContent() {
+    return content;
+  }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+  /**
+   * Sets content.
+   *
+   * @param content the content
+   */
+  public void setContent(String content) {
+    this.content = content;
+  }
 
-        TakenHintDTO hintDTO = (TakenHintDTO) o;
+  public int getOrder() {
+    return order;
+  }
 
-        if (!id.equals(hintDTO.id)) return false;
-        if (!title.equals(hintDTO.title)) return false;
-        return content.equals(hintDTO.content);
-    }
+  public void setOrder(int order) {
+    this.order = order;
+  }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(id, title, content);
-    }
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
 
-    @Override
-    public String toString() {
-        return "TakenHintDTO{" +
-                "id=" + id +
-                ", title='" + title + '\'' +
-                ", content='" + content + '\'' +
-                ", order=" + order +
-                '}';
-    }
+    TakenHintDTO hintDTO = (TakenHintDTO) o;
+
+    if (!id.equals(hintDTO.id)) return false;
+    if (!title.equals(hintDTO.title)) return false;
+    return content.equals(hintDTO.content);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, title, content);
+  }
 }

--- a/training-persistence/src/main/java/cz/cyberrange/platform/training/persistence/model/detection/AbstractDetectionEvent.java
+++ b/training-persistence/src/main/java/cz/cyberrange/platform/training/persistence/model/detection/AbstractDetectionEvent.java
@@ -3,11 +3,7 @@ package cz.cyberrange.platform.training.persistence.model.detection;
 import cz.cyberrange.platform.training.persistence.model.AbstractEntity;
 import cz.cyberrange.platform.training.persistence.model.Submission;
 import cz.cyberrange.platform.training.persistence.model.enums.DetectionEventType;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
-
+import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -17,15 +13,16 @@ import javax.persistence.InheritanceType;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.Table;
-import java.time.LocalDateTime;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 /**
- * Class representing Detection event.
- * Detection event occurs based on a submission
- * Detection events can be created based on suspicious
- * submissions in a training instance.
+ * Class representing Detection event. Detection event occurs based on a submission Detection events
+ * can be created based on suspicious submissions in a training instance.
  */
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @Getter
 @Setter
 @ToString
@@ -33,62 +30,71 @@ import java.time.LocalDateTime;
 @Table(name = "abstract_detection_event")
 @Inheritance(strategy = InheritanceType.JOINED)
 @NamedQueries({
-        @NamedQuery(
-                name = "AbstractDetectionEvent.deleteDetectionEventsOfTrainingInstance",
-                query = "DELETE FROM AbstractDetectionEvent de " +
-                        "WHERE de.trainingInstanceId = :trainingInstanceId"
-        ),
-        @NamedQuery(
-                name = "AbstractDetectionEvent.findAllByCheatingDetectionId",
-                query = "SELECT de FROM AbstractDetectionEvent de " +
-                        "WHERE de.cheatingDetectionId = :cheatingDetectionId"
-        ),
-        @NamedQuery(
-                name = "AbstractDetectionEvent.deleteDetectionEventsOfCheatingDetection",
-                query = "DELETE FROM AbstractDetectionEvent de WHERE de.cheatingDetectionId = :cheatingDetectionId"
-        ),
-        @NamedQuery(
-                name = "AbstractDetectionEvent.getNumberOfDetections",
-                query = "SELECT COUNT(de) FROM AbstractDetectionEvent de WHERE de.cheatingDetectionId = :cheatingDetectionId"
-        ),
-        @NamedQuery(
-                name = "AbstractDetectionEvent.findDetectionEventById",
-                query = "SELECT de FROM AbstractDetectionEvent de WHERE de.id = :eventId"
-        )
+  @NamedQuery(
+      name = "AbstractDetectionEvent.deleteDetectionEventsOfTrainingInstance",
+      query =
+          "DELETE FROM AbstractDetectionEvent de "
+              + "WHERE de.trainingInstanceId = :trainingInstanceId"),
+  @NamedQuery(
+      name = "AbstractDetectionEvent.findAllByCheatingDetectionId",
+      query =
+          "SELECT de FROM AbstractDetectionEvent de "
+              + "WHERE de.cheatingDetectionId = :cheatingDetectionId"),
+  @NamedQuery(
+      name = "AbstractDetectionEvent.deleteDetectionEventsOfCheatingDetection",
+      query =
+          "DELETE FROM AbstractDetectionEvent de WHERE de.cheatingDetectionId = :cheatingDetectionId"),
+  @NamedQuery(
+      name = "AbstractDetectionEvent.getNumberOfDetections",
+      query =
+          "SELECT COUNT(de) FROM AbstractDetectionEvent de WHERE de.cheatingDetectionId = :cheatingDetectionId"),
+  @NamedQuery(
+      name = "AbstractDetectionEvent.findDetectionEventById",
+      query = "SELECT de FROM AbstractDetectionEvent de WHERE de.id = :eventId")
 })
 public class AbstractDetectionEvent extends AbstractEntity<Long> {
 
-    @Column(name = "training_instance_id", nullable = false)
-    private Long trainingInstanceId;
-    @Column(name = "cheating_detection_id", nullable = false)
-    private Long cheatingDetectionId;
-    @Column(name = "training_run_id")
-    private Long trainingRunId;
-    @Column(name = "level_id", nullable = false)
-    private Long levelId;
-    @Column(name = "level_order", nullable = false)
-    private int levelOrder;
-    @Column(name = "level_title", nullable = false)
-    private String levelTitle;
-    @Column(name = "detected_at", nullable = false)
-    private LocalDateTime detectedAt;
-    @Column(name = "participant_count", nullable = false)
-    private int participantCount;
-    @Enumerated(EnumType.STRING)
-    @Column(name = "detection_event_type", nullable = false)
-    private DetectionEventType detectionEventType;
-    @Column(name = "participants", nullable = false)
-    private String participants;
+  @Column(name = "training_instance_id", nullable = false)
+  private Long trainingInstanceId;
 
-    public void setCommonDetectionEventParameters(Submission submission, CheatingDetection cd, DetectionEventType type, int size) {
-        this.setCheatingDetectionId(cd.getId());
-        this.setDetectedAt(cd.getExecuteTime());
-        this.setTrainingRunId(submission.getTrainingRun().getId());
-        this.setLevelId(submission.getLevel().getId());
-        this.setLevelOrder(submission.getLevel().getOrder());
-        this.setLevelTitle(submission.getLevel().getTitle());
-        this.setTrainingInstanceId(cd.getTrainingInstanceId());
-        this.setDetectionEventType(type);
-        this.setParticipantCount(size);
-    }
+  @Column(name = "cheating_detection_id", nullable = false)
+  private Long cheatingDetectionId;
+
+  @Column(name = "training_run_id")
+  private Long trainingRunId;
+
+  @Column(name = "level_id", nullable = false)
+  private Long levelId;
+
+  @Column(name = "level_order", nullable = false)
+  private int levelOrder;
+
+  @Column(name = "level_title", nullable = false)
+  private String levelTitle;
+
+  @Column(name = "detected_at", nullable = false)
+  private LocalDateTime detectedAt;
+
+  @Column(name = "participant_count", nullable = false)
+  private int participantCount;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "detection_event_type", nullable = false)
+  private DetectionEventType detectionEventType;
+
+  @Column(name = "participants", nullable = false)
+  private String participants;
+
+  public void setCommonDetectionEventParameters(
+      Submission submission, CheatingDetection cd, DetectionEventType type, int size) {
+    this.setCheatingDetectionId(cd.getId());
+    this.setDetectedAt(cd.getExecuteTime());
+    this.setTrainingRunId(submission.getTrainingRun().getId());
+    this.setLevelId(submission.getLevel().getId());
+    this.setLevelOrder(submission.getLevel().getOrder());
+    this.setLevelTitle(submission.getLevel().getTitle());
+    this.setTrainingInstanceId(cd.getTrainingInstanceId());
+    this.setDetectionEventType(type);
+    this.setParticipantCount(size);
+  }
 }

--- a/training-persistence/src/main/java/cz/cyberrange/platform/training/persistence/model/detection/AnswerSimilarityDetectionEvent.java
+++ b/training-persistence/src/main/java/cz/cyberrange/platform/training/persistence/model/detection/AnswerSimilarityDetectionEvent.java
@@ -1,18 +1,17 @@
 package cz.cyberrange.platform.training.persistence.model.detection;
 
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
-
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.PrimaryKeyJoinColumn;
 import javax.persistence.Table;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
 @Getter
 @Setter
 @ToString
@@ -20,19 +19,19 @@ import javax.persistence.Table;
 @Table(name = "answer_similarity_detection_event")
 @PrimaryKeyJoinColumn(name = "id")
 @NamedQueries({
-        @NamedQuery(
-                name = "AnswerSimilarityDetectionEvent.findAnswerSimilarityEventById",
-                query = "SELECT asde FROM AnswerSimilarityDetectionEvent asde WHERE asde.id = :eventId"
-        ),
-        @NamedQuery(
-                name = "AnswerSimilarityDetectionEvent.findAllByCheatingDetectionId",
-                query = "SELECT asde FROM AnswerSimilarityDetectionEvent asde WHERE asde.cheatingDetectionId = :cheatingDetectionId"
-        )
+  @NamedQuery(
+      name = "AnswerSimilarityDetectionEvent.findAnswerSimilarityEventById",
+      query = "SELECT asde FROM AnswerSimilarityDetectionEvent asde WHERE asde.id = :eventId"),
+  @NamedQuery(
+      name = "AnswerSimilarityDetectionEvent.findAllByCheatingDetectionId",
+      query =
+          "SELECT asde FROM AnswerSimilarityDetectionEvent asde WHERE asde.cheatingDetectionId = :cheatingDetectionId")
 })
 public class AnswerSimilarityDetectionEvent extends AbstractDetectionEvent {
 
-    @Column(name = "answer")
-    private String answer;
-    @Column(name = "answer_owner", nullable = false)
-    private String answerOwner;
+  @Column(name = "answer")
+  private String answer;
+
+  @Column(name = "answer_owner", nullable = false)
+  private String answerOwner;
 }

--- a/training-persistence/src/main/java/cz/cyberrange/platform/training/persistence/model/detection/CheatingDetection.java
+++ b/training-persistence/src/main/java/cz/cyberrange/platform/training/persistence/model/detection/CheatingDetection.java
@@ -2,100 +2,107 @@ package cz.cyberrange.platform.training.persistence.model.detection;
 
 import cz.cyberrange.platform.training.persistence.model.AbstractEntity;
 import cz.cyberrange.platform.training.persistence.model.enums.CheatingDetectionState;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.*;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
-import javax.persistence.*;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-
 /**
- * Class representing cheating detection.
- * Cheating detections are executed by organizers.
- * Cheating detections are bound to a training instance.
+ * Class representing cheating detection. Cheating detections are executed by organizers. Cheating
+ * detections are bound to a training instance.
  */
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @Getter
 @Setter
 @ToString
 @Entity
 @Table(name = "cheating_detection")
 @NamedQueries({
-        @NamedQuery(
-                name = "CheatingDetection.findAllByTrainingInstanceId",
-                query = "SELECT cd FROM CheatingDetection cd " +
-                        "WHERE cd.trainingInstanceId = :trainingInstanceId " +
-                        "ORDER BY cd.executeTime"
-        ),
-        @NamedQuery(
-                name = "CheatingDetection.findCheatingDetectionById",
-                query = "SELECT cd FROM CheatingDetection cd " +
-                        "WHERE cd.id = :cheatingDetectionId"
-        ),
-        @NamedQuery(
-                name = "CheatingDetection.deleteCheatingDetectionById",
-                query = "DELETE FROM CheatingDetection cd WHERE cd.id = :cheatingDetectionId"
-        ),
-        @NamedQuery(
-                name = "CheatingDetection.deleteAllCheatingDetectionsOfTrainingInstance",
-                query = "DELETE FROM CheatingDetection cd WHERE cd.trainingInstanceId = :trainingInstanceId"
-        )
+  @NamedQuery(
+      name = "CheatingDetection.findAllByTrainingInstanceId",
+      query =
+          "SELECT cd FROM CheatingDetection cd "
+              + "WHERE cd.trainingInstanceId = :trainingInstanceId "
+              + "ORDER BY cd.executeTime"),
+  @NamedQuery(
+      name = "CheatingDetection.findCheatingDetectionById",
+      query = "SELECT cd FROM CheatingDetection cd " + "WHERE cd.id = :cheatingDetectionId"),
+  @NamedQuery(
+      name = "CheatingDetection.deleteCheatingDetectionById",
+      query = "DELETE FROM CheatingDetection cd WHERE cd.id = :cheatingDetectionId"),
+  @NamedQuery(
+      name = "CheatingDetection.deleteAllCheatingDetectionsOfTrainingInstance",
+      query = "DELETE FROM CheatingDetection cd WHERE cd.trainingInstanceId = :trainingInstanceId")
 })
 public class CheatingDetection extends AbstractEntity<Long> {
 
-    @Column(name = "training_instance_id", nullable = false)
-    private Long trainingInstanceId;
-    @Column(name = "executed_by")
-    private String executedBy;
-    @Column(name = "execute_time", nullable = false)
-    private LocalDateTime executeTime;
-    @Column(name = "proximity_threshold", nullable = true)
-    private Long proximityThreshold;
-    @Enumerated(EnumType.STRING)
-    @Column(name = "current_state", nullable = false)
-    private CheatingDetectionState currentState;
-    @Column(name = "results")
-    private Long results;
-    @Enumerated(EnumType.STRING)
-    @Column(name = "answer_similarity_state")
-    private CheatingDetectionState answerSimilarityState;
-    @Enumerated(EnumType.STRING)
-    @Column(name = "location_similarity_state")
-    private CheatingDetectionState locationSimilarityState;
-    @Enumerated(EnumType.STRING)
-    @Column(name = "time_proximity_state")
-    private CheatingDetectionState timeProximityState;
-    @Enumerated(EnumType.STRING)
-    @Column(name = "minimal_solve_time_state")
-    private CheatingDetectionState minimalSolveTimeState;
-    @Enumerated(EnumType.STRING)
-    @Column(name = "forbidden_commands_state")
-    private CheatingDetectionState forbiddenCommandsState;
-    @Enumerated(EnumType.STRING)
-    @Column(name = "no_commands_state")
-    private CheatingDetectionState noCommandsState;
-    @OneToMany(
-            mappedBy = "cheatingDetection",
-            cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE},
-            orphanRemoval = true,
-            fetch = FetchType.LAZY
-    )
-    private List<ForbiddenCommand> commands = new ArrayList<>();
+  @Column(name = "training_instance_id", nullable = false)
+  private Long trainingInstanceId;
 
-    private CheatingDetectionState setExecuteState(CheatingDetectionState state) {
-        return state != CheatingDetectionState.DISABLED ? CheatingDetectionState.QUEUED : CheatingDetectionState.DISABLED;
-    }
+  @Column(name = "executed_by")
+  private String executedBy;
 
-    public void setExecuteStates() {
-        this.setCurrentState(CheatingDetectionState.RUNNING);
-        this.setAnswerSimilarityState(setExecuteState(this.getAnswerSimilarityState()));
-        this.setLocationSimilarityState(setExecuteState(this.getLocationSimilarityState()));
-        this.setMinimalSolveTimeState(setExecuteState(this.getMinimalSolveTimeState()));
-        this.setTimeProximityState(setExecuteState(this.getTimeProximityState()));
-        this.setNoCommandsState(setExecuteState(this.getNoCommandsState()));
-        this.setForbiddenCommandsState(setExecuteState(this.getForbiddenCommandsState()));
-    }
+  @Column(name = "execute_time", nullable = false)
+  private LocalDateTime executeTime;
+
+  @Column(name = "proximity_threshold", nullable = true)
+  private Long proximityThreshold;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "current_state", nullable = false)
+  private CheatingDetectionState currentState;
+
+  @Column(name = "results")
+  private Long results;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "answer_similarity_state")
+  private CheatingDetectionState answerSimilarityState;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "location_similarity_state")
+  private CheatingDetectionState locationSimilarityState;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "time_proximity_state")
+  private CheatingDetectionState timeProximityState;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "minimal_solve_time_state")
+  private CheatingDetectionState minimalSolveTimeState;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "forbidden_commands_state")
+  private CheatingDetectionState forbiddenCommandsState;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "no_commands_state")
+  private CheatingDetectionState noCommandsState;
+
+  @OneToMany(
+      mappedBy = "cheatingDetection",
+      cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE},
+      orphanRemoval = true,
+      fetch = FetchType.LAZY)
+  private List<ForbiddenCommand> commands = new ArrayList<>();
+
+  private CheatingDetectionState setExecuteState(CheatingDetectionState state) {
+    return state != CheatingDetectionState.DISABLED
+        ? CheatingDetectionState.QUEUED
+        : CheatingDetectionState.DISABLED;
+  }
+
+  public void setExecuteStates() {
+    this.setCurrentState(CheatingDetectionState.RUNNING);
+    this.setAnswerSimilarityState(setExecuteState(this.getAnswerSimilarityState()));
+    this.setLocationSimilarityState(setExecuteState(this.getLocationSimilarityState()));
+    this.setMinimalSolveTimeState(setExecuteState(this.getMinimalSolveTimeState()));
+    this.setTimeProximityState(setExecuteState(this.getTimeProximityState()));
+    this.setNoCommandsState(setExecuteState(this.getNoCommandsState()));
+    this.setForbiddenCommandsState(setExecuteState(this.getForbiddenCommandsState()));
+  }
 }

--- a/training-persistence/src/main/java/cz/cyberrange/platform/training/persistence/model/detection/DetectedForbiddenCommand.java
+++ b/training-persistence/src/main/java/cz/cyberrange/platform/training/persistence/model/detection/DetectedForbiddenCommand.java
@@ -2,45 +2,47 @@ package cz.cyberrange.platform.training.persistence.model.detection;
 
 import cz.cyberrange.platform.training.persistence.model.AbstractEntity;
 import cz.cyberrange.platform.training.persistence.model.enums.CommandType;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
-
+import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.Table;
-import java.time.LocalDateTime;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
 @Getter
 @Setter
 @ToString
 @Entity
 @Table(name = "detected_forbidden_command")
 @NamedQueries({
-        @NamedQuery(
-                name = "DetectedForbiddenCommand.findAllByEventId",
-                query = "SELECT dfc FROM DetectedForbiddenCommand dfc " +
-                        "WHERE dfc.detectionEventId = :eventId"
-        ),
-        @NamedQuery(
-                name = "DetectedForbiddenCommand.deleteAllByDetectionEventId",
-                query = "DELETE FROM DetectedForbiddenCommand dfc WHERE dfc.detectionEventId = :eventId"
-        )
+  @NamedQuery(
+      name = "DetectedForbiddenCommand.findAllByEventId",
+      query =
+          "SELECT dfc FROM DetectedForbiddenCommand dfc "
+              + "WHERE dfc.detectionEventId = :eventId"),
+  @NamedQuery(
+      name = "DetectedForbiddenCommand.deleteAllByDetectionEventId",
+      query = "DELETE FROM DetectedForbiddenCommand dfc WHERE dfc.detectionEventId = :eventId")
 })
 public class DetectedForbiddenCommand extends AbstractEntity<Long> {
 
-    @Column(name = "command", nullable = false)
-    private String command;
-    @Column(name = "command_type", nullable = false)
-    private CommandType type;
-    @Column(name = "detection_event_id", nullable = false)
-    private Long detectionEventId;
-    @Column(name = "hostname")
-    private String hostname;
-    @Column(name = "occurred_at")
-    private LocalDateTime occurredAt;
+  @Column(name = "command", nullable = false)
+  private String command;
+
+  @Column(name = "command_type", nullable = false)
+  private CommandType type;
+
+  @Column(name = "detection_event_id", nullable = false)
+  private Long detectionEventId;
+
+  @Column(name = "hostname")
+  private String hostname;
+
+  @Column(name = "occurred_at")
+  private LocalDateTime occurredAt;
 }

--- a/training-persistence/src/main/java/cz/cyberrange/platform/training/persistence/model/detection/DetectionEventParticipant.java
+++ b/training-persistence/src/main/java/cz/cyberrange/platform/training/persistence/model/detection/DetectionEventParticipant.java
@@ -1,50 +1,55 @@
 package cz.cyberrange.platform.training.persistence.model.detection;
 
 import cz.cyberrange.platform.training.persistence.model.AbstractEntity;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
-
+import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.Table;
-import java.time.LocalDateTime;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
 @Getter
 @Setter
 @ToString
 @Entity
 @Table(name = "detection_event_participant")
 @NamedQueries({
-        @NamedQuery(
-                name = "DetectionEventParticipant.findAllByEventId",
-                query = "SELECT dep FROM DetectionEventParticipant dep " +
-                        "WHERE dep.detectionEventId = :eventId " +
-                        "ORDER BY dep.occurredAt"
-        ),
-        @NamedQuery(
-                name = "DetectionEventParticipant.deleteAllParticipantsByCheatingDetectionId",
-                query = "DELETE FROM DetectionEventParticipant dep WHERE dep.cheatingDetectionId = :cheatingDetectionId"
-        )
+  @NamedQuery(
+      name = "DetectionEventParticipant.findAllByEventId",
+      query =
+          "SELECT dep FROM DetectionEventParticipant dep "
+              + "WHERE dep.detectionEventId = :eventId "
+              + "ORDER BY dep.occurredAt"),
+  @NamedQuery(
+      name = "DetectionEventParticipant.deleteAllParticipantsByCheatingDetectionId",
+      query =
+          "DELETE FROM DetectionEventParticipant dep WHERE dep.cheatingDetectionId = :cheatingDetectionId")
 })
 public class DetectionEventParticipant extends AbstractEntity<Long> {
 
-    @Column(name = "ip_address", nullable = true)
-    private String ipAddress;
-    @Column(name = "occurred_at", nullable = true)
-    private LocalDateTime occurredAt;
-    @Column(name = "participant_name", nullable = false)
-    private String participantName;
-    @Column(name = "solved_in_time", nullable = true)
-    private Long solvedInTime;
-    @Column(name = "user_id", nullable = false)
-    private Long userId;
-    @Column(name = "detection_event_id", nullable = false)
-    private Long detectionEventId;
-    @Column(name = "cheating_detection_id", nullable = false)
-    private Long cheatingDetectionId;
+  @Column(name = "ip_address", nullable = true)
+  private String ipAddress;
+
+  @Column(name = "occurred_at", nullable = true)
+  private LocalDateTime occurredAt;
+
+  @Column(name = "participant_name", nullable = false)
+  private String participantName;
+
+  @Column(name = "solved_in_time", nullable = true)
+  private Long solvedInTime;
+
+  @Column(name = "user_id", nullable = false)
+  private Long userId;
+
+  @Column(name = "detection_event_id", nullable = false)
+  private Long detectionEventId;
+
+  @Column(name = "cheating_detection_id", nullable = false)
+  private Long cheatingDetectionId;
 }

--- a/training-persistence/src/main/java/cz/cyberrange/platform/training/persistence/model/detection/ForbiddenCommand.java
+++ b/training-persistence/src/main/java/cz/cyberrange/platform/training/persistence/model/detection/ForbiddenCommand.java
@@ -2,19 +2,18 @@ package cz.cyberrange.platform.training.persistence.model.detection;
 
 import cz.cyberrange.platform.training.persistence.model.AbstractEntity;
 import cz.cyberrange.platform.training.persistence.model.enums.CommandType;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
-
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
 @Getter
 @Setter
 @ToString
@@ -22,11 +21,13 @@ import javax.persistence.Table;
 @Table(name = "forbidden_command")
 public class ForbiddenCommand extends AbstractEntity<Long> {
 
-    @Column(name = "command", nullable = false)
-    private String command;
-    @Column(name = "command_type", nullable = false)
-    private CommandType type;
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "cheating_detection_id")
-    private CheatingDetection cheatingDetection;
+  @Column(name = "command", nullable = false)
+  private String command;
+
+  @Column(name = "command_type", nullable = false)
+  private CommandType type;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "cheating_detection_id")
+  private CheatingDetection cheatingDetection;
 }

--- a/training-persistence/src/main/java/cz/cyberrange/platform/training/persistence/model/detection/ForbiddenCommandsDetectionEvent.java
+++ b/training-persistence/src/main/java/cz/cyberrange/platform/training/persistence/model/detection/ForbiddenCommandsDetectionEvent.java
@@ -1,18 +1,17 @@
 package cz.cyberrange.platform.training.persistence.model.detection;
 
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
-
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.PrimaryKeyJoinColumn;
 import javax.persistence.Table;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
 @Getter
 @Setter
 @ToString
@@ -20,17 +19,16 @@ import javax.persistence.Table;
 @Table(name = "forbidden_commands_detection_event")
 @PrimaryKeyJoinColumn(name = "id")
 @NamedQueries({
-        @NamedQuery(
-                name = "ForbiddenCommandsDetectionEvent.findForbiddenCommandsEventById",
-                query = "SELECT fcde FROM ForbiddenCommandsDetectionEvent fcde WHERE fcde.id = :eventId"
-        ),
-        @NamedQuery(
-                name = "ForbiddenCommandsDetectionEvent.findAllByCheatingDetectionId",
-                query = "SELECT fcde FROM ForbiddenCommandsDetectionEvent fcde WHERE fcde.cheatingDetectionId = :cheatingDetectionId"
-        )
+  @NamedQuery(
+      name = "ForbiddenCommandsDetectionEvent.findForbiddenCommandsEventById",
+      query = "SELECT fcde FROM ForbiddenCommandsDetectionEvent fcde WHERE fcde.id = :eventId"),
+  @NamedQuery(
+      name = "ForbiddenCommandsDetectionEvent.findAllByCheatingDetectionId",
+      query =
+          "SELECT fcde FROM ForbiddenCommandsDetectionEvent fcde WHERE fcde.cheatingDetectionId = :cheatingDetectionId")
 })
 public class ForbiddenCommandsDetectionEvent extends AbstractDetectionEvent {
 
-    @Column(name = "command_count", nullable = false)
-    private int commandCount;
+  @Column(name = "command_count", nullable = false)
+  private int commandCount;
 }

--- a/training-persistence/src/main/java/cz/cyberrange/platform/training/persistence/model/detection/LocationSimilarityDetectionEvent.java
+++ b/training-persistence/src/main/java/cz/cyberrange/platform/training/persistence/model/detection/LocationSimilarityDetectionEvent.java
@@ -1,18 +1,17 @@
 package cz.cyberrange.platform.training.persistence.model.detection;
 
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
-
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.PrimaryKeyJoinColumn;
 import javax.persistence.Table;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
 @Getter
 @Setter
 @ToString
@@ -20,23 +19,22 @@ import javax.persistence.Table;
 @Table(name = "location_similarity_detection_event")
 @PrimaryKeyJoinColumn(name = "id")
 @NamedQueries({
-        @NamedQuery(
-                name = "LocationSimilarityDetectionEvent.findLocationSimilarityEventById",
-                query = "SELECT lsde FROM LocationSimilarityDetectionEvent lsde WHERE lsde.id = :eventId"
-        ),
-        @NamedQuery(
-                name = "LocationSimilarityDetectionEvent.findAllByCheatingDetectionId",
-                query = "SELECT lsde FROM LocationSimilarityDetectionEvent lsde WHERE lsde.cheatingDetectionId = :cheatingDetectionId"
-        )
+  @NamedQuery(
+      name = "LocationSimilarityDetectionEvent.findLocationSimilarityEventById",
+      query = "SELECT lsde FROM LocationSimilarityDetectionEvent lsde WHERE lsde.id = :eventId"),
+  @NamedQuery(
+      name = "LocationSimilarityDetectionEvent.findAllByCheatingDetectionId",
+      query =
+          "SELECT lsde FROM LocationSimilarityDetectionEvent lsde WHERE lsde.cheatingDetectionId = :cheatingDetectionId")
 })
 public class LocationSimilarityDetectionEvent extends AbstractDetectionEvent {
 
-    @Column(name = "ip_address")
-    private String ipAddress;
+  @Column(name = "ip_address")
+  private String ipAddress;
 
-    @Column(name = "dns")
-    private String dns;
+  @Column(name = "dns")
+  private String dns;
 
-    @Column(name = "is_address_deploy")
-    private boolean isAddressDeploy;
+  @Column(name = "is_address_deploy")
+  private boolean isAddressDeploy;
 }

--- a/training-persistence/src/main/java/cz/cyberrange/platform/training/persistence/model/detection/MinimalSolveTimeDetectionEvent.java
+++ b/training-persistence/src/main/java/cz/cyberrange/platform/training/persistence/model/detection/MinimalSolveTimeDetectionEvent.java
@@ -1,18 +1,17 @@
 package cz.cyberrange.platform.training.persistence.model.detection;
 
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
-
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.PrimaryKeyJoinColumn;
 import javax.persistence.Table;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
 @Getter
 @Setter
 @ToString
@@ -20,17 +19,16 @@ import javax.persistence.Table;
 @Table(name = "minimal_solve_time_detection_event")
 @PrimaryKeyJoinColumn(name = "id")
 @NamedQueries({
-        @NamedQuery(
-                name = "MinimalSolveTimeDetectionEvent.findMinimalSolveTimeEventById",
-                query = "SELECT mstde FROM MinimalSolveTimeDetectionEvent mstde WHERE mstde.id = :eventId"
-        ),
-        @NamedQuery(
-                name = "MinimalSolveTimeDetectionEvent.findAllByCheatingDetectionId",
-                query = "SELECT mstde FROM MinimalSolveTimeDetectionEvent mstde WHERE mstde.cheatingDetectionId = :cheatingDetectionId"
-        )
+  @NamedQuery(
+      name = "MinimalSolveTimeDetectionEvent.findMinimalSolveTimeEventById",
+      query = "SELECT mstde FROM MinimalSolveTimeDetectionEvent mstde WHERE mstde.id = :eventId"),
+  @NamedQuery(
+      name = "MinimalSolveTimeDetectionEvent.findAllByCheatingDetectionId",
+      query =
+          "SELECT mstde FROM MinimalSolveTimeDetectionEvent mstde WHERE mstde.cheatingDetectionId = :cheatingDetectionId")
 })
 public class MinimalSolveTimeDetectionEvent extends AbstractDetectionEvent {
 
-    @Column(name = "minimal_solve_time")
-    private Long minimalSolveTime;
+  @Column(name = "minimal_solve_time")
+  private Long minimalSolveTime;
 }

--- a/training-persistence/src/main/java/cz/cyberrange/platform/training/persistence/model/detection/NoCommandsDetectionEvent.java
+++ b/training-persistence/src/main/java/cz/cyberrange/platform/training/persistence/model/detection/NoCommandsDetectionEvent.java
@@ -1,27 +1,25 @@
 package cz.cyberrange.platform.training.persistence.model.detection;
 
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
-
 import javax.persistence.Entity;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.PrimaryKeyJoinColumn;
 import javax.persistence.Table;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
 @ToString
 @Entity
 @Table(name = "no_commands_detection_event")
 @PrimaryKeyJoinColumn(name = "id")
 @NamedQueries({
-        @NamedQuery(
-                name = "NoCommandsDetectionEvent.findNoCommandsEventById",
-                query = "SELECT ncde FROM NoCommandsDetectionEvent ncde WHERE ncde.id = :eventId"
-        ),
-        @NamedQuery(
-                name = "NoCommandsDetectionEvent.findAllByCheatingDetectionId",
-                query = "SELECT ncde FROM NoCommandsDetectionEvent ncde WHERE ncde.cheatingDetectionId = :cheatingDetectionId"
-        )
+  @NamedQuery(
+      name = "NoCommandsDetectionEvent.findNoCommandsEventById",
+      query = "SELECT ncde FROM NoCommandsDetectionEvent ncde WHERE ncde.id = :eventId"),
+  @NamedQuery(
+      name = "NoCommandsDetectionEvent.findAllByCheatingDetectionId",
+      query =
+          "SELECT ncde FROM NoCommandsDetectionEvent ncde WHERE ncde.cheatingDetectionId = :cheatingDetectionId")
 })
-public class NoCommandsDetectionEvent extends AbstractDetectionEvent { }
+public class NoCommandsDetectionEvent extends AbstractDetectionEvent {}

--- a/training-persistence/src/main/java/cz/cyberrange/platform/training/persistence/model/detection/TimeProximityDetectionEvent.java
+++ b/training-persistence/src/main/java/cz/cyberrange/platform/training/persistence/model/detection/TimeProximityDetectionEvent.java
@@ -1,18 +1,17 @@
 package cz.cyberrange.platform.training.persistence.model.detection;
 
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
-
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.PrimaryKeyJoinColumn;
 import javax.persistence.Table;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
 @Getter
 @Setter
 @ToString
@@ -20,17 +19,16 @@ import javax.persistence.Table;
 @Table(name = "time_proximity_detection_event")
 @PrimaryKeyJoinColumn(name = "id")
 @NamedQueries({
-        @NamedQuery(
-                name = "TimeProximityDetectionEvent.findTimeProximityEventById",
-                query = "SELECT tpde FROM TimeProximityDetectionEvent tpde WHERE tpde.id = :eventId"
-        ),
-        @NamedQuery(
-                name = "TimeProximityDetectionEvent.findAllByCheatingDetectionId",
-                query = "SELECT tpde FROM TimeProximityDetectionEvent tpde WHERE tpde.cheatingDetectionId = :cheatingDetectionId"
-        )
+  @NamedQuery(
+      name = "TimeProximityDetectionEvent.findTimeProximityEventById",
+      query = "SELECT tpde FROM TimeProximityDetectionEvent tpde WHERE tpde.id = :eventId"),
+  @NamedQuery(
+      name = "TimeProximityDetectionEvent.findAllByCheatingDetectionId",
+      query =
+          "SELECT tpde FROM TimeProximityDetectionEvent tpde WHERE tpde.cheatingDetectionId = :cheatingDetectionId")
 })
 public class TimeProximityDetectionEvent extends AbstractDetectionEvent {
 
-    @Column(name = "threshold")
-    private Long threshold;
+  @Column(name = "threshold")
+  private Long threshold;
 }

--- a/training-rest/src/test/java/cz/cyberrange/platform/training/rest/integration/TrainingDefinitionsIT.java
+++ b/training-rest/src/test/java/cz/cyberrange/platform/training/rest/integration/TrainingDefinitionsIT.java
@@ -1,5 +1,16 @@
 package cz.cyberrange.platform.training.rest.integration;
 
+import static cz.cyberrange.platform.training.rest.controllers.util.ObjectConverter.convertJsonBytesToObject;
+import static cz.cyberrange.platform.training.rest.controllers.util.ObjectConverter.convertObjectToJsonBytes;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -53,6 +64,18 @@ import cz.cyberrange.platform.training.rest.utils.error.CustomRestExceptionHandl
 import cz.cyberrange.platform.training.service.enums.RoleTypeSecurity;
 import cz.cyberrange.platform.training.service.mapping.mapstruct.LevelMapperImpl;
 import cz.cyberrange.platform.training.service.mapping.mapstruct.TrainingDefinitionMapperImpl;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
 import org.apache.http.HttpHeaders;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -90,1404 +113,2013 @@ import org.springframework.web.reactive.function.client.ExchangeFunction;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
-import javax.persistence.EntityManager;
-import javax.transaction.Transactional;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import static cz.cyberrange.platform.training.rest.controllers.util.ObjectConverter.convertJsonBytesToObject;
-import static cz.cyberrange.platform.training.rest.controllers.util.ObjectConverter.convertObjectToJsonBytes;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doReturn;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-@SpringBootTest(classes = {
-        TrainingDefinitionsRestController.class,
-        IntegrationTestApplication.class,
-        TestDataFactory.class
-})
+@SpringBootTest(
+    classes = {
+      TrainingDefinitionsRestController.class,
+      IntegrationTestApplication.class,
+      TestDataFactory.class
+    })
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
 @Transactional
 public class TrainingDefinitionsIT {
 
-    @Mock
-    private Appender<ILoggingEvent> mockAppender;
+  @Mock private Appender<ILoggingEvent> mockAppender;
 
-    private MockMvc mvc;
-    private static final Logger logger = LoggerFactory.getLogger(TrainingDefinitionsRestController.class);
+  private MockMvc mvc;
+  private static final Logger logger =
+      LoggerFactory.getLogger(TrainingDefinitionsRestController.class);
 
-    @Autowired
-    private TestDataFactory testDataFactory;
-    @Autowired
-    private ApplicationContext applicationContext;
-    @Autowired
-    private TrainingDefinitionsRestController trainingDefinitionsRestController;
-    @Autowired
-    private LevelMapperImpl levelMapper;
-    @Autowired
-    private TrainingDefinitionRepository trainingDefinitionRepository;
-    @Autowired
-    private UserRefRepository userRefRepository;
-    @Autowired
-    private TrainingLevelRepository trainingLevelRepository;
-    @Autowired
-    private InfoLevelRepository infoLevelRepository;
-    @Autowired
-    private AssessmentLevelRepository assessmentLevelRepository;
-    @Autowired
-    private TrainingInstanceRepository trainingInstanceRepository;
-    @Autowired
-    private EntityManager entityManager;
-    @Autowired
-    @Qualifier("objMapperRESTApi")
-    private ObjectMapper mapper;
+  @Autowired private TestDataFactory testDataFactory;
+  @Autowired private ApplicationContext applicationContext;
+  @Autowired private TrainingDefinitionsRestController trainingDefinitionsRestController;
+  @Autowired private LevelMapperImpl levelMapper;
+  @Autowired private TrainingDefinitionRepository trainingDefinitionRepository;
+  @Autowired private UserRefRepository userRefRepository;
+  @Autowired private TrainingLevelRepository trainingLevelRepository;
+  @Autowired private InfoLevelRepository infoLevelRepository;
+  @Autowired private AssessmentLevelRepository assessmentLevelRepository;
+  @Autowired private TrainingInstanceRepository trainingInstanceRepository;
+  @Autowired private EntityManager entityManager;
 
-    @Autowired
-    @Qualifier("userManagementExchangeFunction")
-    private ExchangeFunction exchangeFunction;
+  @Autowired
+  @Qualifier("objMapperRESTApi")
+  private ObjectMapper mapper;
 
-    @Mock
-    private WebClient.Builder webClientBuilder;
+  @Autowired
+  @Qualifier("userManagementExchangeFunction")
+  private ExchangeFunction exchangeFunction;
 
-    @Autowired
-    private TrainingDefinitionMapperImpl trainingDefinitionMapper;
+  @Mock private WebClient.Builder webClientBuilder;
 
-    private TrainingDefinitionUpdateDTO trainingDefinitionUpdateDTO, invalidDefinitionUpdateDTO;
-    private TrainingDefinitionCreateDTO trainingDefinitionCreateDTO;
-    private TrainingDefinitionByIdDTO invalidDefinitionDTO;
-    private TrainingDefinition releasedTrainingDefinition, unreleasedTrainingDefinition, archivedTrainingDefinition;
-    private TrainingDefinitionDTO releasedTrainingDefinitionDTO, unreleasedTrainingDefinitionDTO, archivedTrainingDefinitionDTO;
-    private TrainingDefinitionInfoDTO releasedTrainingDefinitionInfoDTO, unreleasedTrainingDefinitionInfoDTO, archivedTrainingDefinitionInfoDTO;
-    private TrainingInstance trainingInstance;
-    private UserRef organizer1, organizer2, author1, author2;
-    private TrainingLevel trainingLevel1, trainingLevel2;
-    private TrainingLevelUpdateDTO trainingLevelUpdateDTO, invalidTrainingLevelUpdateDTO;
-    private InfoLevel infoLevel1;
-    private InfoLevelUpdateDTO infoLevelUpdateDTO, invalidInfoLevelUpdateDTO;
-    private AssessmentLevel assessmentLevelWithoutQuestions, assessmentLevelWithQuestions;
-    private AssessmentLevelUpdateDTO assessmentLevelUpdateDTO, invalidAssessmentLevelUpdateDTO;
-    private UserRefDTO organizerDTO1, organizerDTO2, authorDTO1, authorDTO2;
-    private MitreTechnique mitreTechnique1, mitreTechnique2;
-    private MitreTechniqueDTO mitreTechniqueDTO1, mitreTechniqueDTO2;
+  @Autowired private TrainingDefinitionMapperImpl trainingDefinitionMapper;
 
-    @BeforeEach
-    public void init() {
-        this.mvc = MockMvcBuilders.standaloneSetup(trainingDefinitionsRestController)
-                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver(),
-                        new QuerydslPredicateArgumentResolver(
-                                new QuerydslBindingsFactory(SimpleEntityPathResolver.INSTANCE), Optional.empty()))
-                .setMessageConverters(new MappingJackson2HttpMessageConverter(mapper))
-                .setControllerAdvice(new CustomRestExceptionHandlerTraining())
-                .build();
+  private TrainingDefinitionUpdateDTO trainingDefinitionUpdateDTO, invalidDefinitionUpdateDTO;
+  private TrainingDefinitionCreateDTO trainingDefinitionCreateDTO;
+  private TrainingDefinitionByIdDTO invalidDefinitionDTO;
+  private TrainingDefinition releasedTrainingDefinition,
+      unreleasedTrainingDefinition,
+      archivedTrainingDefinition;
+  private TrainingDefinitionDTO releasedTrainingDefinitionDTO,
+      unreleasedTrainingDefinitionDTO,
+      archivedTrainingDefinitionDTO;
+  private TrainingDefinitionInfoDTO releasedTrainingDefinitionInfoDTO,
+      unreleasedTrainingDefinitionInfoDTO,
+      archivedTrainingDefinitionInfoDTO;
+  private TrainingInstance trainingInstance;
+  private UserRef organizer1, organizer2, author1, author2;
+  private TrainingLevel trainingLevel1, trainingLevel2;
+  private TrainingLevelUpdateDTO trainingLevelUpdateDTO, invalidTrainingLevelUpdateDTO;
+  private InfoLevel infoLevel1;
+  private InfoLevelUpdateDTO infoLevelUpdateDTO, invalidInfoLevelUpdateDTO;
+  private AssessmentLevel assessmentLevelWithoutQuestions, assessmentLevelWithQuestions;
+  private AssessmentLevelUpdateDTO assessmentLevelUpdateDTO, invalidAssessmentLevelUpdateDTO;
+  private UserRefDTO organizerDTO1, organizerDTO2, authorDTO1, authorDTO2;
+  private MitreTechnique mitreTechnique1, mitreTechnique2;
+  private MitreTechniqueDTO mitreTechniqueDTO1, mitreTechniqueDTO2;
 
-        organizer1 = testDataFactory.getUserRef1();
-        organizer2 = testDataFactory.getUserRef2();
-        author1 = testDataFactory.getUserRef3();
-        author2 = testDataFactory.getUserRef4();
-        userRefRepository.saveAll(List.of(organizer1, organizer2, author1, author2));
+  @BeforeEach
+  public void init() {
+    this.mvc =
+        MockMvcBuilders.standaloneSetup(trainingDefinitionsRestController)
+            .setCustomArgumentResolvers(
+                new PageableHandlerMethodArgumentResolver(),
+                new QuerydslPredicateArgumentResolver(
+                    new QuerydslBindingsFactory(SimpleEntityPathResolver.INSTANCE),
+                    Optional.empty()))
+            .setMessageConverters(new MappingJackson2HttpMessageConverter(mapper))
+            .setControllerAdvice(new CustomRestExceptionHandlerTraining())
+            .build();
 
+    organizer1 = testDataFactory.getUserRef1();
+    organizer2 = testDataFactory.getUserRef2();
+    author1 = testDataFactory.getUserRef3();
+    author2 = testDataFactory.getUserRef4();
+    userRefRepository.saveAll(List.of(organizer1, organizer2, author1, author2));
 
-        organizerDTO1 = testDataFactory.getUserRefDTO1();
-        organizerDTO2 = testDataFactory.getUserRefDTO2();
-        authorDTO1 = testDataFactory.getUserRefDTO3();
-        authorDTO2 = testDataFactory.getUserRefDTO4();
+    organizerDTO1 = testDataFactory.getUserRefDTO1();
+    organizerDTO2 = testDataFactory.getUserRefDTO2();
+    authorDTO1 = testDataFactory.getUserRefDTO3();
+    authorDTO2 = testDataFactory.getUserRefDTO4();
 
-        trainingLevel1 = testDataFactory.getPenalizedLevel();
-        trainingLevelUpdateDTO = testDataFactory.getTrainingLevelUpdateDTO();
-        invalidTrainingLevelUpdateDTO = new TrainingLevelUpdateDTO();
-        trainingLevel2 = testDataFactory.getNonPenalizedLevel();
+    trainingLevel1 = testDataFactory.getPenalizedLevel();
+    trainingLevelUpdateDTO = testDataFactory.getTrainingLevelUpdateDTO();
+    invalidTrainingLevelUpdateDTO = new TrainingLevelUpdateDTO();
+    trainingLevel2 = testDataFactory.getNonPenalizedLevel();
 
-        infoLevel1 = testDataFactory.getInfoLevel1();
-        infoLevelUpdateDTO = testDataFactory.getInfoLevelUpdateDTO();
-        invalidInfoLevelUpdateDTO = new InfoLevelUpdateDTO();
+    infoLevel1 = testDataFactory.getInfoLevel1();
+    infoLevelUpdateDTO = testDataFactory.getInfoLevelUpdateDTO();
+    invalidInfoLevelUpdateDTO = new InfoLevelUpdateDTO();
 
-        assessmentLevelWithoutQuestions = testDataFactory.getQuestionnaire();
-        this.createAssessmentLevelWithQuestions();
-        this.createAssessmentLevelUpdateDTO();
-        invalidAssessmentLevelUpdateDTO = new AssessmentLevelUpdateDTO();
+    assessmentLevelWithoutQuestions = testDataFactory.getQuestionnaire();
+    this.createAssessmentLevelWithQuestions();
+    this.createAssessmentLevelUpdateDTO();
+    invalidAssessmentLevelUpdateDTO = new AssessmentLevelUpdateDTO();
 
-        trainingDefinitionCreateDTO = testDataFactory.getTrainingDefinitionCreateDTO();
+    trainingDefinitionCreateDTO = testDataFactory.getTrainingDefinitionCreateDTO();
 
-        invalidDefinitionDTO = new TrainingDefinitionByIdDTO();
+    invalidDefinitionDTO = new TrainingDefinitionByIdDTO();
 
-        releasedTrainingDefinition = testDataFactory.getReleasedDefinition();
-        releasedTrainingDefinition.setAuthors(new HashSet<>(List.of(author1)));
-        unreleasedTrainingDefinition = testDataFactory.getUnreleasedDefinition();
-        unreleasedTrainingDefinition.setAuthors(new HashSet<>(Collections.singletonList(author1)));
-        archivedTrainingDefinition = testDataFactory.getArchivedDefinition();
-        archivedTrainingDefinition.setAuthors(Set.of(author1));
+    releasedTrainingDefinition = testDataFactory.getReleasedDefinition();
+    releasedTrainingDefinition.setAuthors(new HashSet<>(List.of(author1)));
+    unreleasedTrainingDefinition = testDataFactory.getUnreleasedDefinition();
+    unreleasedTrainingDefinition.setAuthors(new HashSet<>(Collections.singletonList(author1)));
+    archivedTrainingDefinition = testDataFactory.getArchivedDefinition();
+    archivedTrainingDefinition.setAuthors(Set.of(author1));
 
-        releasedTrainingDefinitionInfoDTO = testDataFactory.getReleasedDefinitionInfoDTO();
-        unreleasedTrainingDefinitionInfoDTO = testDataFactory.getUnreleasedDefinitionInfoDTO();
-        archivedTrainingDefinitionInfoDTO = testDataFactory.getArchivedDefinitionInfoDTO();
+    releasedTrainingDefinitionInfoDTO = testDataFactory.getReleasedDefinitionInfoDTO();
+    unreleasedTrainingDefinitionInfoDTO = testDataFactory.getUnreleasedDefinitionInfoDTO();
+    archivedTrainingDefinitionInfoDTO = testDataFactory.getArchivedDefinitionInfoDTO();
 
-        unreleasedTrainingDefinitionDTO = testDataFactory.getUnreleasedDefinitionDTO();
-        unreleasedTrainingDefinitionDTO.setCanBeArchived(true);
-        releasedTrainingDefinitionDTO = testDataFactory.getReleasedDefinitionDTO();
-        releasedTrainingDefinitionDTO.setCanBeArchived(true);
-        archivedTrainingDefinitionDTO = testDataFactory.getArchivedDefinitionDTO();
-        archivedTrainingDefinitionDTO.setCanBeArchived(true);
-        trainingDefinitionUpdateDTO = testDataFactory.getTrainingDefinitionUpdateDTO();
-        invalidDefinitionUpdateDTO = new TrainingDefinitionUpdateDTO();
+    unreleasedTrainingDefinitionDTO = testDataFactory.getUnreleasedDefinitionDTO();
+    unreleasedTrainingDefinitionDTO.setCanBeArchived(true);
+    releasedTrainingDefinitionDTO = testDataFactory.getReleasedDefinitionDTO();
+    releasedTrainingDefinitionDTO.setCanBeArchived(true);
+    archivedTrainingDefinitionDTO = testDataFactory.getArchivedDefinitionDTO();
+    archivedTrainingDefinitionDTO.setCanBeArchived(true);
+    trainingDefinitionUpdateDTO = testDataFactory.getTrainingDefinitionUpdateDTO();
+    invalidDefinitionUpdateDTO = new TrainingDefinitionUpdateDTO();
 
-        trainingInstance = testDataFactory.getOngoingInstance();
-        trainingInstance.setOrganizers(Set.of(author1));
+    trainingInstance = testDataFactory.getOngoingInstance();
+    trainingInstance.setOrganizers(Set.of(author1));
 
-        mitreTechnique1 = testDataFactory.getMitreTechnique1();
-        mitreTechnique2 = testDataFactory.getMitreTechnique2();
-        mitreTechniqueDTO1 = testDataFactory.getMitreTechniqueDTO1();
-        mitreTechniqueDTO2 = testDataFactory.getMitreTechniqueDTO2();
+    mitreTechnique1 = testDataFactory.getMitreTechnique1();
+    mitreTechnique2 = testDataFactory.getMitreTechnique2();
+    mitreTechniqueDTO1 = testDataFactory.getMitreTechniqueDTO1();
+    mitreTechniqueDTO2 = testDataFactory.getMitreTechniqueDTO2();
 
-        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-    }
+    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+  }
 
-    private void createAssessmentLevelWithQuestions() {
-        assessmentLevelWithQuestions = testDataFactory.getTest();
-        entityManager.persist(assessmentLevelWithQuestions);
-        Question freeFormQuestion = testDataFactory.getFreeFormQuestion();
-        freeFormQuestion.setAssessmentLevel(assessmentLevelWithQuestions);
-        entityManager.persist(freeFormQuestion);
-        freeFormQuestion.setChoices(testDataFactory.getQuestionChoices(3, "Free form option", Collections.nCopies(3, true), freeFormQuestion));
+  private void createAssessmentLevelWithQuestions() {
+    assessmentLevelWithQuestions = testDataFactory.getTest();
+    entityManager.persist(assessmentLevelWithQuestions);
+    Question freeFormQuestion = testDataFactory.getFreeFormQuestion();
+    freeFormQuestion.setAssessmentLevel(assessmentLevelWithQuestions);
+    entityManager.persist(freeFormQuestion);
+    freeFormQuestion.setChoices(
+        testDataFactory.getQuestionChoices(
+            3, "Free form option", Collections.nCopies(3, true), freeFormQuestion));
 
-        Question multipleChoiceQuestion = testDataFactory.getMultipleChoiceQuestion();
-        entityManager.persist(multipleChoiceQuestion);
-        multipleChoiceQuestion.setChoices(testDataFactory.getQuestionChoices(3, "Multiple choice option", List.of(true, false, true), multipleChoiceQuestion));
+    Question multipleChoiceQuestion = testDataFactory.getMultipleChoiceQuestion();
+    entityManager.persist(multipleChoiceQuestion);
+    multipleChoiceQuestion.setChoices(
+        testDataFactory.getQuestionChoices(
+            3, "Multiple choice option", List.of(true, false, true), multipleChoiceQuestion));
 
-        Question extendedMatchingItemsQuestion = testDataFactory.getExtendedMatchingStatements();
-        entityManager.persist(extendedMatchingItemsQuestion);
+    Question extendedMatchingItemsQuestion = testDataFactory.getExtendedMatchingStatements();
+    entityManager.persist(extendedMatchingItemsQuestion);
 
-        List<ExtendedMatchingOption> extendedMatchingOptions = testDataFactory.getExtendedMatchingOptions(4, "Option ", extendedMatchingItemsQuestion);
-        extendedMatchingItemsQuestion.setExtendedMatchingOptions(extendedMatchingOptions);
-        extendedMatchingItemsQuestion.setExtendedMatchingStatements(testDataFactory.getExtendedMatchingStatements(3, "Statement ", extendedMatchingItemsQuestion));
-        AtomicInteger index = new AtomicInteger();
-        extendedMatchingItemsQuestion.getExtendedMatchingStatements().forEach(item -> item.setExtendedMatchingOption(extendedMatchingOptions.get(index.getAndIncrement() % 4)));
-        assessmentLevelWithQuestions.setQuestions(new ArrayList<>(List.of(freeFormQuestion, multipleChoiceQuestion, extendedMatchingItemsQuestion)));
-    }
+    List<ExtendedMatchingOption> extendedMatchingOptions =
+        testDataFactory.getExtendedMatchingOptions(4, "Option ", extendedMatchingItemsQuestion);
+    extendedMatchingItemsQuestion.setExtendedMatchingOptions(extendedMatchingOptions);
+    extendedMatchingItemsQuestion.setExtendedMatchingStatements(
+        testDataFactory.getExtendedMatchingStatements(
+            3, "Statement ", extendedMatchingItemsQuestion));
+    AtomicInteger index = new AtomicInteger();
+    extendedMatchingItemsQuestion
+        .getExtendedMatchingStatements()
+        .forEach(
+            item ->
+                item.setExtendedMatchingOption(
+                    extendedMatchingOptions.get(index.getAndIncrement() % 4)));
+    assessmentLevelWithQuestions.setQuestions(
+        new ArrayList<>(
+            List.of(freeFormQuestion, multipleChoiceQuestion, extendedMatchingItemsQuestion)));
+  }
 
-    private void createAssessmentLevelUpdateDTO() {
-        assessmentLevelUpdateDTO = testDataFactory.getAssessmentLevelUpdateDTO();
-        QuestionDTO freeFormQuestionDTO = testDataFactory.getFreeFormQuestionDTO();
-        freeFormQuestionDTO.setChoices(testDataFactory.getQuestionChoiceDTOs(2, "Free form option update", Collections.nCopies(2, true)));
+  private void createAssessmentLevelUpdateDTO() {
+    assessmentLevelUpdateDTO = testDataFactory.getAssessmentLevelUpdateDTO();
+    QuestionDTO freeFormQuestionDTO = testDataFactory.getFreeFormQuestionDTO();
+    freeFormQuestionDTO.setChoices(
+        testDataFactory.getQuestionChoiceDTOs(
+            2, "Free form option update", Collections.nCopies(2, true)));
 
-        QuestionDTO multipleChoiceQuestionDTO = testDataFactory.getMultipleChoiceQuestionDTO();
-        multipleChoiceQuestionDTO.setChoices(testDataFactory.getQuestionChoiceDTOs(4, "Multiple choice option upudate", List.of(true, false, false, false)));
+    QuestionDTO multipleChoiceQuestionDTO = testDataFactory.getMultipleChoiceQuestionDTO();
+    multipleChoiceQuestionDTO.setChoices(
+        testDataFactory.getQuestionChoiceDTOs(
+            4, "Multiple choice option upudate", List.of(true, false, false, false)));
 
-        QuestionDTO extendedMatchingItemsQuestionDTO = testDataFactory.getExtendedMatchingItemsDTO();
-        List<ExtendedMatchingOptionDTO> extendedMatchingOptionDTOs = testDataFactory.getExtendedMatchingOptionDTOs(4, "Option ");
-        extendedMatchingItemsQuestionDTO.setExtendedMatchingOptions(extendedMatchingOptionDTOs);
-        extendedMatchingItemsQuestionDTO.setExtendedMatchingStatements(testDataFactory.getExtendedMatchingItemDTOs(3, "Statement ", List.of(3, 1, 2)));
-        assessmentLevelUpdateDTO.setQuestions(new ArrayList<>(List.of(freeFormQuestionDTO, multipleChoiceQuestionDTO, extendedMatchingItemsQuestionDTO)));
-    }
+    QuestionDTO extendedMatchingItemsQuestionDTO = testDataFactory.getExtendedMatchingItemsDTO();
+    List<ExtendedMatchingOptionDTO> extendedMatchingOptionDTOs =
+        testDataFactory.getExtendedMatchingOptionDTOs(4, "Option ");
+    extendedMatchingItemsQuestionDTO.setExtendedMatchingOptions(extendedMatchingOptionDTOs);
+    extendedMatchingItemsQuestionDTO.setExtendedMatchingStatements(
+        testDataFactory.getExtendedMatchingItemDTOs(3, "Statement ", List.of(3, 1, 2)));
+    assessmentLevelUpdateDTO.setQuestions(
+        new ArrayList<>(
+            List.of(
+                freeFormQuestionDTO, multipleChoiceQuestionDTO, extendedMatchingItemsQuestionDTO)));
+  }
 
-    @AfterEach
-    public void reset() throws Exception {
-        DBTestUtil.resetAutoIncrementColumns(applicationContext, "training_definition", "abstract_level");
-    }
+  @AfterEach
+  public void reset() throws Exception {
+    DBTestUtil.resetAutoIncrementColumns(
+        applicationContext, "training_definition", "abstract_level");
+  }
 
-    @Test
-    public void findTrainingDefinitionById() throws Exception {
-        TrainingDefinition expected = trainingDefinitionRepository.save(releasedTrainingDefinition);
-        TrainingLevel trainingLevel = trainingLevelRepository.save(trainingLevel1);
-        trainingLevel.setTrainingDefinition(expected);
-        trainingDefinitionRepository.save(expected);
+  @Test
+  public void findTrainingDefinitionById() throws Exception {
+    TrainingDefinition expected = trainingDefinitionRepository.save(releasedTrainingDefinition);
+    TrainingLevel trainingLevel = trainingLevelRepository.save(trainingLevel1);
+    trainingLevel.setTrainingDefinition(expected);
+    trainingDefinitionRepository.save(expected);
 
-        MockHttpServletResponse result = mvc.perform(get("/training-definitions" + "/{id}", expected.getId()))
-                .andExpect(status().isOk())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andReturn().getResponse();
+    MockHttpServletResponse result =
+        mvc.perform(get("/training-definitions" + "/{id}", expected.getId()))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andReturn()
+            .getResponse();
 
-        TrainingDefinitionByIdDTO definitionDTO = trainingDefinitionMapper.mapToDTOById(expected);
-        TrainingLevelDTO trainingLevelDTO = levelMapper.mapToTrainingLevelDTO(trainingLevel1);
-        trainingLevelDTO.setLevelType(LevelType.TRAINING_LEVEL);
-        definitionDTO.setLevels(new ArrayList<>(Collections.singleton(trainingLevelDTO)));
-        assertEquals(definitionDTO, convertJsonBytesToObject(convertJsonBytesToObject(result.getContentAsString()), TrainingDefinitionByIdDTO.class));
-    }
+    TrainingDefinitionByIdDTO definitionDTO = trainingDefinitionMapper.mapToDTOById(expected);
+    TrainingLevelDTO trainingLevelDTO = levelMapper.mapToTrainingLevelDTO(trainingLevel1);
+    trainingLevelDTO.setLevelType(LevelType.TRAINING_LEVEL);
+    definitionDTO.setLevels(new ArrayList<>(Collections.singleton(trainingLevelDTO)));
+    assertEquals(
+        definitionDTO,
+        convertJsonBytesToObject(
+            convertJsonBytesToObject(result.getContentAsString()),
+            TrainingDefinitionByIdDTO.class));
+  }
 
-    @Test
-    public void findTrainingDefinitionById_NotFound() throws Exception {
-        MockHttpServletResponse response = mvc.perform(get("/training-definitions" + "/{id}", 100L))
-                .andExpect(status().isNotFound())
-                .andReturn().getResponse();
-        ApiEntityError error = convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
-        assertEquals(HttpStatus.NOT_FOUND, error.getStatus());
-        assertEntityDetailError(error.getEntityErrorDetail(), TrainingDefinition.class, "id", "100",
-                "Entity TrainingDefinition (id: 100) not found.");
-    }
+  @Test
+  public void findTrainingDefinitionById_NotFound() throws Exception {
+    MockHttpServletResponse response =
+        mvc.perform(get("/training-definitions" + "/{id}", 100L))
+            .andExpect(status().isNotFound())
+            .andReturn()
+            .getResponse();
+    ApiEntityError error =
+        convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
+    assertEquals(HttpStatus.NOT_FOUND, error.getStatus());
+    assertEntityDetailError(
+        error.getEntityErrorDetail(),
+        TrainingDefinition.class,
+        "id",
+        "100",
+        "Entity TrainingDefinition (id: 100) not found.");
+  }
 
-    @Test
-    public void findAllTrainingDefinitions_AdminRole() throws Exception {
-        trainingDefinitionRepository.save(releasedTrainingDefinition);
-        trainingDefinitionRepository.save(unreleasedTrainingDefinition);
-        trainingDefinitionRepository.save(archivedTrainingDefinition);
-        mockSpringSecurityContextForGet(List.of(RoleTypeSecurity.ROLE_TRAINING_ADMINISTRATOR.name()));
+  @Test
+  public void findAllTrainingDefinitions_AdminRole() throws Exception {
+    trainingDefinitionRepository.save(releasedTrainingDefinition);
+    trainingDefinitionRepository.save(unreleasedTrainingDefinition);
+    trainingDefinitionRepository.save(archivedTrainingDefinition);
+    mockSpringSecurityContextForGet(List.of(RoleTypeSecurity.ROLE_TRAINING_ADMINISTRATOR.name()));
 
-        MockHttpServletResponse result = mvc.perform(get("/training-definitions"))
-                .andExpect(status().isOk())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andReturn().getResponse();
-        PageResultResource<TrainingDefinitionDTO> trainingDefinitionsPage = convertJsonBytesToObject(convertJsonBytesToObject(
-                result.getContentAsString()), new TypeReference<PageResultResource<TrainingDefinitionDTO>>() {});
-        releasedTrainingDefinitionDTO.setId(releasedTrainingDefinition.getId());
-        unreleasedTrainingDefinitionDTO.setId(unreleasedTrainingDefinition.getId());
-        archivedTrainingDefinitionDTO.setId(archivedTrainingDefinition.getId());
-        assertTrue(trainingDefinitionsPage.getContent().containsAll(Set.of(releasedTrainingDefinitionDTO, unreleasedTrainingDefinitionDTO, archivedTrainingDefinitionDTO)));
-    }
+    MockHttpServletResponse result =
+        mvc.perform(get("/training-definitions"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andReturn()
+            .getResponse();
+    PageResultResource<TrainingDefinitionDTO> trainingDefinitionsPage =
+        convertJsonBytesToObject(
+            convertJsonBytesToObject(result.getContentAsString()),
+            new TypeReference<PageResultResource<TrainingDefinitionDTO>>() {});
+    releasedTrainingDefinitionDTO.setId(releasedTrainingDefinition.getId());
+    unreleasedTrainingDefinitionDTO.setId(unreleasedTrainingDefinition.getId());
+    archivedTrainingDefinitionDTO.setId(archivedTrainingDefinition.getId());
+    assertTrue(
+        trainingDefinitionsPage
+            .getContent()
+            .containsAll(
+                Set.of(
+                    releasedTrainingDefinitionDTO,
+                    unreleasedTrainingDefinitionDTO,
+                    archivedTrainingDefinitionDTO)));
+  }
 
-    @Test
-    public void findAllTrainingDefinitions() throws Exception {
-        trainingDefinitionRepository.save(releasedTrainingDefinition);
-        trainingDefinitionRepository.save(unreleasedTrainingDefinition);
-        trainingDefinitionRepository.save(archivedTrainingDefinition);
-        releasedTrainingDefinition.setAuthors(Set.of(author1, author2, organizer1));
-        unreleasedTrainingDefinition.setAuthors(Set.of(organizer1, organizer2));
-        mockSpringSecurityContextForGet(List.of(RoleTypeSecurity.ROLE_TRAINING_ORGANIZER.name()));
-        doReturn(buildMockResponse(organizerDTO1)).when(exchangeFunction).exchange(any(ClientRequest.class));
+  @Test
+  public void findAllTrainingDefinitions() throws Exception {
+    trainingDefinitionRepository.save(releasedTrainingDefinition);
+    trainingDefinitionRepository.save(unreleasedTrainingDefinition);
+    trainingDefinitionRepository.save(archivedTrainingDefinition);
+    releasedTrainingDefinition.setAuthors(Set.of(author1, author2, organizer1));
+    unreleasedTrainingDefinition.setAuthors(Set.of(organizer1, organizer2));
+    mockSpringSecurityContextForGet(List.of(RoleTypeSecurity.ROLE_TRAINING_ORGANIZER.name()));
+    doReturn(buildMockResponse(organizerDTO1))
+        .when(exchangeFunction)
+        .exchange(any(ClientRequest.class));
 
-        MockHttpServletResponse result = mvc.perform(get("/training-definitions"))
-                .andExpect(status().isOk())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andReturn().getResponse();
-        PageResultResource<TrainingDefinitionDTO> trainingDefinitionsPage = convertJsonBytesToObject(convertJsonBytesToObject(
-                result.getContentAsString()), new TypeReference<PageResultResource<TrainingDefinitionDTO>>() {});
-        releasedTrainingDefinitionDTO.setId(releasedTrainingDefinition.getId());
-        unreleasedTrainingDefinitionDTO.setId(unreleasedTrainingDefinition.getId());
-        assertTrue(trainingDefinitionsPage.getContent().containsAll(Set.of(releasedTrainingDefinitionDTO, unreleasedTrainingDefinitionDTO)));
-    }
+    MockHttpServletResponse result =
+        mvc.perform(get("/training-definitions"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andReturn()
+            .getResponse();
+    PageResultResource<TrainingDefinitionDTO> trainingDefinitionsPage =
+        convertJsonBytesToObject(
+            convertJsonBytesToObject(result.getContentAsString()),
+            new TypeReference<PageResultResource<TrainingDefinitionDTO>>() {});
+    releasedTrainingDefinitionDTO.setId(releasedTrainingDefinition.getId());
+    unreleasedTrainingDefinitionDTO.setId(unreleasedTrainingDefinition.getId());
+    assertTrue(
+        trainingDefinitionsPage
+            .getContent()
+            .containsAll(Set.of(releasedTrainingDefinitionDTO, unreleasedTrainingDefinitionDTO)));
+  }
 
-    @Test
-    public void findAllTrainingDefinitionsForOrganizers_Released() throws Exception {
-        trainingDefinitionRepository.save(releasedTrainingDefinition);
-        trainingDefinitionRepository.save(unreleasedTrainingDefinition);
-        trainingDefinitionRepository.save(archivedTrainingDefinition);
-        releasedTrainingDefinition.setAuthors(Set.of(author1, author2, organizer1));
-        unreleasedTrainingDefinition.setAuthors(Set.of(organizer1, organizer2));
-        mockSpringSecurityContextForGet(List.of(RoleTypeSecurity.ROLE_TRAINING_ORGANIZER.name()));
-        doReturn(buildMockResponse(organizerDTO1)).when(exchangeFunction).exchange(any(ClientRequest.class));
+  @Test
+  public void findAllTrainingDefinitionsForOrganizers_Released() throws Exception {
+    trainingDefinitionRepository.save(releasedTrainingDefinition);
+    trainingDefinitionRepository.save(unreleasedTrainingDefinition);
+    trainingDefinitionRepository.save(archivedTrainingDefinition);
+    releasedTrainingDefinition.setAuthors(Set.of(author1, author2, organizer1));
+    unreleasedTrainingDefinition.setAuthors(Set.of(organizer1, organizer2));
+    mockSpringSecurityContextForGet(List.of(RoleTypeSecurity.ROLE_TRAINING_ORGANIZER.name()));
+    doReturn(buildMockResponse(organizerDTO1))
+        .when(exchangeFunction)
+        .exchange(any(ClientRequest.class));
 
-        MockHttpServletResponse result = mvc.perform(get("/training-definitions")
-                .queryParam("state", "RELEASED"))
-                .andExpect(status().isOk())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andReturn().getResponse();
-        PageResultResource<TrainingDefinitionInfoDTO> trainingDefinitionsPage = convertJsonBytesToObject(convertJsonBytesToObject(
-                result.getContentAsString()), new TypeReference<PageResultResource<TrainingDefinitionInfoDTO>>() {});
-        releasedTrainingDefinitionInfoDTO.setId(releasedTrainingDefinition.getId());
-        assertTrue(trainingDefinitionsPage.getContent().contains(releasedTrainingDefinitionInfoDTO));
-    }
+    MockHttpServletResponse result =
+        mvc.perform(get("/training-definitions").queryParam("state", "RELEASED"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andReturn()
+            .getResponse();
+    PageResultResource<TrainingDefinitionInfoDTO> trainingDefinitionsPage =
+        convertJsonBytesToObject(
+            convertJsonBytesToObject(result.getContentAsString()),
+            new TypeReference<PageResultResource<TrainingDefinitionInfoDTO>>() {});
+    releasedTrainingDefinitionInfoDTO.setId(releasedTrainingDefinition.getId());
+    assertTrue(trainingDefinitionsPage.getContent().contains(releasedTrainingDefinitionInfoDTO));
+  }
 
-    @Test
-    public void findAllTrainingDefinitionsForOrganizers_Unreleased_Admin() throws Exception {
-        trainingDefinitionRepository.save(releasedTrainingDefinition);
-        trainingDefinitionRepository.save(unreleasedTrainingDefinition);
-        trainingDefinitionRepository.save(archivedTrainingDefinition);
-        releasedTrainingDefinition.setAuthors(Set.of(author1, author2, organizer1));
-        unreleasedTrainingDefinition.setAuthors(Set.of(organizer2));
-        mockSpringSecurityContextForGet(List.of(RoleTypeSecurity.ROLE_TRAINING_ADMINISTRATOR.name()));
-        doReturn(buildMockResponse(organizerDTO1)).when(exchangeFunction).exchange(any(ClientRequest.class));
+  @Test
+  public void findAllTrainingDefinitionsForOrganizers_Unreleased_Admin() throws Exception {
+    trainingDefinitionRepository.save(releasedTrainingDefinition);
+    trainingDefinitionRepository.save(unreleasedTrainingDefinition);
+    trainingDefinitionRepository.save(archivedTrainingDefinition);
+    releasedTrainingDefinition.setAuthors(Set.of(author1, author2, organizer1));
+    unreleasedTrainingDefinition.setAuthors(Set.of(organizer2));
+    mockSpringSecurityContextForGet(List.of(RoleTypeSecurity.ROLE_TRAINING_ADMINISTRATOR.name()));
+    doReturn(buildMockResponse(organizerDTO1))
+        .when(exchangeFunction)
+        .exchange(any(ClientRequest.class));
 
-        MockHttpServletResponse result = mvc.perform(get("/training-definitions")
-                .queryParam("state", "UNRELEASED"))
-                .andExpect(status().isOk())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andReturn().getResponse();
-        PageResultResource<TrainingDefinitionInfoDTO> trainingDefinitionsPage = convertJsonBytesToObject(convertJsonBytesToObject(
-                result.getContentAsString()), new TypeReference<PageResultResource<TrainingDefinitionInfoDTO>>() {});
-        unreleasedTrainingDefinitionInfoDTO.setId(unreleasedTrainingDefinition.getId());
-        assertTrue(trainingDefinitionsPage.getContent().contains(unreleasedTrainingDefinitionInfoDTO));
-    }
+    MockHttpServletResponse result =
+        mvc.perform(get("/training-definitions").queryParam("state", "UNRELEASED"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andReturn()
+            .getResponse();
+    PageResultResource<TrainingDefinitionInfoDTO> trainingDefinitionsPage =
+        convertJsonBytesToObject(
+            convertJsonBytesToObject(result.getContentAsString()),
+            new TypeReference<PageResultResource<TrainingDefinitionInfoDTO>>() {});
+    unreleasedTrainingDefinitionInfoDTO.setId(unreleasedTrainingDefinition.getId());
+    assertTrue(trainingDefinitionsPage.getContent().contains(unreleasedTrainingDefinitionInfoDTO));
+  }
 
-    @Test
-    public void findAllTrainingDefinitionsForOrganizers_Unreleased_OrganizerAndDesigner() throws Exception {
-        trainingDefinitionRepository.save(releasedTrainingDefinition);
-        trainingDefinitionRepository.save(unreleasedTrainingDefinition);
-        trainingDefinitionRepository.save(archivedTrainingDefinition);
-        releasedTrainingDefinition.setAuthors(Set.of(author1, author2, organizer1));
-        unreleasedTrainingDefinition.setAuthors(Set.of(organizer1));
-        mockSpringSecurityContextForGet(List.of(RoleTypeSecurity.ROLE_TRAINING_DESIGNER.name(), RoleTypeSecurity.ROLE_TRAINING_ORGANIZER.name()));
-        doReturn(buildMockResponse(organizerDTO1)).when(exchangeFunction).exchange(any(ClientRequest.class));
+  @Test
+  public void findAllTrainingDefinitionsForOrganizers_Unreleased_OrganizerAndDesigner()
+      throws Exception {
+    trainingDefinitionRepository.save(releasedTrainingDefinition);
+    trainingDefinitionRepository.save(unreleasedTrainingDefinition);
+    trainingDefinitionRepository.save(archivedTrainingDefinition);
+    releasedTrainingDefinition.setAuthors(Set.of(author1, author2, organizer1));
+    unreleasedTrainingDefinition.setAuthors(Set.of(organizer1));
+    mockSpringSecurityContextForGet(
+        List.of(
+            RoleTypeSecurity.ROLE_TRAINING_DESIGNER.name(),
+            RoleTypeSecurity.ROLE_TRAINING_ORGANIZER.name()));
+    doReturn(buildMockResponse(organizerDTO1))
+        .when(exchangeFunction)
+        .exchange(any(ClientRequest.class));
 
-        MockHttpServletResponse result = mvc.perform(get("/training-definitions")
-                .queryParam("state", "UNRELEASED"))
-                .andExpect(status().isOk())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andReturn().getResponse();
-        PageResultResource<TrainingDefinitionInfoDTO> trainingDefinitionsPage = convertJsonBytesToObject(convertJsonBytesToObject(
-                result.getContentAsString()), new TypeReference<PageResultResource<TrainingDefinitionInfoDTO>>() {});
-        unreleasedTrainingDefinitionInfoDTO.setId(unreleasedTrainingDefinition.getId());
-        assertTrue(trainingDefinitionsPage.getContent().contains(unreleasedTrainingDefinitionInfoDTO));
-    }
+    MockHttpServletResponse result =
+        mvc.perform(get("/training-definitions").queryParam("state", "UNRELEASED"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andReturn()
+            .getResponse();
+    PageResultResource<TrainingDefinitionInfoDTO> trainingDefinitionsPage =
+        convertJsonBytesToObject(
+            convertJsonBytesToObject(result.getContentAsString()),
+            new TypeReference<PageResultResource<TrainingDefinitionInfoDTO>>() {});
+    unreleasedTrainingDefinitionInfoDTO.setId(unreleasedTrainingDefinition.getId());
+    assertTrue(trainingDefinitionsPage.getContent().contains(unreleasedTrainingDefinitionInfoDTO));
+  }
 
-    @Test
-    public void createTrainingDefinition() throws Exception {
-        mockSpringSecurityContextForGet(List.of(RoleTypeSecurity.ROLE_TRAINING_DESIGNER.name()));
-        given(exchangeFunction.exchange(any(ClientRequest.class))).willReturn(buildMockResponse(organizerDTO1));
+  @Test
+  public void createTrainingDefinition() throws Exception {
+    mockSpringSecurityContextForGet(List.of(RoleTypeSecurity.ROLE_TRAINING_DESIGNER.name()));
+    given(exchangeFunction.exchange(any(ClientRequest.class)))
+        .willReturn(buildMockResponse(organizerDTO1));
 
-        MockHttpServletResponse result = mvc.perform(post("/training-definitions").content(convertObjectToJsonBytes(trainingDefinitionCreateDTO))
+    MockHttpServletResponse result =
+        mvc.perform(
+                post("/training-definitions")
+                    .content(convertObjectToJsonBytes(trainingDefinitionCreateDTO))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andReturn()
+            .getResponse();
+
+    Optional<TrainingDefinition> newDefinition = trainingDefinitionRepository.findById(1L);
+    assertTrue(newDefinition.isPresent());
+    TrainingDefinitionByIdDTO newDefinitionDTO =
+        trainingDefinitionMapper.mapToDTOById(newDefinition.get());
+    assertEquals(
+        newDefinitionDTO,
+        convertJsonBytesToObject(
+            convertJsonBytesToObject(result.getContentAsString()),
+            TrainingDefinitionByIdDTO.class));
+  }
+
+  @Test
+  public void createTrainingDefinition_InvalidDefinition() throws Exception {
+    Exception ex =
+        mvc.perform(
+                post("/training-definitions")
+                    .content(convertObjectToJsonBytes(invalidDefinitionDTO))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isBadRequest())
+            .andReturn()
+            .getResolvedException();
+    assertTrue(Objects.requireNonNull(ex).getMessage().contains("Validation failed for argument"));
+    assertEquals(ex.getClass(), MethodArgumentNotValidException.class);
+  }
+
+  @Test
+  public void updateTrainingDefinition() throws Exception {
+    trainingDefinitionRepository.save(unreleasedTrainingDefinition);
+    userRefRepository.save(author1);
+    unreleasedTrainingDefinition.addAuthor(author1);
+    trainingDefinitionUpdateDTO.setId(unreleasedTrainingDefinition.getId());
+    doReturn(buildMockResponse(organizerDTO1))
+        .when(exchangeFunction)
+        .exchange(any(ClientRequest.class));
+
+    mvc.perform(
+            put("/training-definitions")
+                .content(convertObjectToJsonBytes(trainingDefinitionUpdateDTO))
                 .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isOk())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andReturn().getResponse();
+        .andExpect(status().isNoContent());
+    Optional<TrainingDefinition> optionalDefinition =
+        trainingDefinitionRepository.findById(unreleasedTrainingDefinition.getId());
+    assertTrue(optionalDefinition.isPresent());
+    TrainingDefinition updatedDefinition = optionalDefinition.get();
+    assertEquals(trainingDefinitionUpdateDTO.getTitle(), updatedDefinition.getTitle());
+    assertEquals(trainingDefinitionUpdateDTO.getDescription(), updatedDefinition.getDescription());
+    assertEquals(
+        trainingDefinitionUpdateDTO.getState().toString(), updatedDefinition.getState().toString());
+    assertEquals(unreleasedTrainingDefinition.getAuthors(), updatedDefinition.getAuthors());
+  }
 
-        Optional<TrainingDefinition> newDefinition = trainingDefinitionRepository.findById(1L);
-        assertTrue(newDefinition.isPresent());
-        TrainingDefinitionByIdDTO newDefinitionDTO = trainingDefinitionMapper.mapToDTOById(newDefinition.get());
-        assertEquals(newDefinitionDTO, convertJsonBytesToObject(convertJsonBytesToObject(result.getContentAsString()), TrainingDefinitionByIdDTO.class));
-    }
+  @Test
+  public void updateTrainingDefinition_InvalidDefinition() throws Exception {
+    Exception ex =
+        mvc.perform(
+                put("/training-definitions")
+                    .content(convertObjectToJsonBytes(invalidDefinitionUpdateDTO))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isBadRequest())
+            .andReturn()
+            .getResolvedException();
+    assertTrue(Objects.requireNonNull(ex).getMessage().contains("Validation failed for argument"));
+    assertEquals(ex.getClass(), MethodArgumentNotValidException.class);
+  }
 
-    @Test
-    public void createTrainingDefinition_InvalidDefinition() throws Exception {
-        Exception ex = mvc.perform(post("/training-definitions").content(convertObjectToJsonBytes(invalidDefinitionDTO))
+  @Test
+  public void updateTrainingDefinition_DefinitionNotFound() throws Exception {
+    trainingDefinitionUpdateDTO.setId(100L);
+    MockHttpServletResponse response =
+        mvc.perform(
+                put("/training-definitions")
+                    .content(convertObjectToJsonBytes(trainingDefinitionUpdateDTO))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isNotFound())
+            .andReturn()
+            .getResponse();
+    ApiEntityError error =
+        convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
+    assertEquals(HttpStatus.NOT_FOUND, error.getStatus());
+    assertEntityDetailError(
+        error.getEntityErrorDetail(),
+        TrainingDefinition.class,
+        "id",
+        "100",
+        "Entity TrainingDefinition (id: 100) not found.");
+  }
+
+  @Test
+  public void updateTrainingDefinition_ReleasedDefinition() throws Exception {
+    trainingDefinitionRepository.save(releasedTrainingDefinition);
+    trainingDefinitionUpdateDTO.setId(releasedTrainingDefinition.getId());
+
+    MockHttpServletResponse response =
+        mvc.perform(
+                put("/training-definitions")
+                    .content(convertObjectToJsonBytes(trainingDefinitionUpdateDTO))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isConflict())
+            .andReturn()
+            .getResponse();
+    ApiEntityError error =
+        convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
+    assertEquals(HttpStatus.CONFLICT, error.getStatus());
+    assertEntityDetailError(
+        error.getEntityErrorDetail(),
+        TrainingDefinition.class,
+        "id",
+        releasedTrainingDefinition.getId().toString(),
+        "Cannot edit released or archived training definition.");
+  }
+
+  @Test
+  public void updateTrainingDefinition_CreatedInstance() throws Exception {
+    trainingDefinitionRepository.save(unreleasedTrainingDefinition);
+    trainingInstance.setTrainingDefinition(unreleasedTrainingDefinition);
+    trainingInstanceRepository.save(trainingInstance);
+    trainingDefinitionUpdateDTO.setId(unreleasedTrainingDefinition.getId());
+
+    MockHttpServletResponse response =
+        mvc.perform(
+                put("/training-definitions")
+                    .content(convertObjectToJsonBytes(trainingDefinitionUpdateDTO))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isConflict())
+            .andReturn()
+            .getResponse();
+    ApiEntityError error =
+        convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
+    assertEquals(HttpStatus.CONFLICT, error.getStatus());
+    assertEntityDetailError(
+        error.getEntityErrorDetail(),
+        TrainingDefinition.class,
+        "id",
+        unreleasedTrainingDefinition.getId().toString(),
+        "Cannot update training definition with already created training instance. Remove training instance/s before updating training definition.");
+  }
+
+  @Test
+  public void cloneTrainingDefinition() throws Exception {
+    trainingDefinitionRepository.save(unreleasedTrainingDefinition);
+    trainingLevel1.setTrainingDefinition(unreleasedTrainingDefinition);
+    trainingLevelRepository.save(trainingLevel1);
+    mockSpringSecurityContextForGet(List.of(RoleTypeSecurity.ROLE_TRAINING_DESIGNER.name()));
+    TrainingDefinitionByIdDTO trainingDefinitionByIdDTO =
+        trainingDefinitionMapper.mapToDTOById(unreleasedTrainingDefinition);
+    trainingDefinitionByIdDTO.setLevels(List.of(levelMapper.mapToDTO(trainingLevel1)));
+
+    MockHttpServletResponse result =
+        mvc.perform(
+                post("/training-definitions" + "/{id}", unreleasedTrainingDefinition.getId())
+                    .param("title", "title"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON_VALUE))
+            .andReturn()
+            .getResponse();
+    Optional<TrainingDefinition> clonedTrainingDefinition =
+        trainingDefinitionRepository.findById(2L);
+    assertTrue(clonedTrainingDefinition.isPresent());
+    assertEquals("title", clonedTrainingDefinition.get().getTitle());
+    assertEquals(
+        clonedTrainingDefinition.get().getState().toString(), TDState.UNRELEASED.toString());
+    assertNull(clonedTrainingDefinition.get().getBetaTestingGroup());
+  }
+
+  @Test
+  public void cloneNonexistentTrainingDefinition() throws Exception {
+    MockHttpServletResponse response =
+        mvc.perform(post("/training-definitions" + "/{id}", 100L).param("title", "title"))
+            .andExpect(status().isNotFound())
+            .andReturn()
+            .getResponse();
+    ApiEntityError error =
+        convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
+    assertEquals(HttpStatus.NOT_FOUND, error.getStatus());
+    assertEntityDetailError(
+        error.getEntityErrorDetail(),
+        TrainingDefinition.class,
+        "id",
+        "100",
+        "Entity TrainingDefinition (id: 100) not found.");
+  }
+
+  @Test
+  public void swapLevels() throws Exception {
+    trainingDefinitionRepository.save(unreleasedTrainingDefinition);
+    infoLevel1.setTrainingDefinition(unreleasedTrainingDefinition);
+    infoLevel1.setOrder(1);
+    trainingLevel2.setTrainingDefinition(unreleasedTrainingDefinition);
+    trainingLevel2.setOrder(2);
+    trainingLevel1.setTrainingDefinition(unreleasedTrainingDefinition);
+    trainingLevel1.setOrder(3);
+    trainingLevelRepository.saveAll(Set.of(trainingLevel1, trainingLevel2));
+    infoLevelRepository.save(infoLevel1);
+
+    mvc.perform(
+            put(
+                "/training-definitions/{definitionId}/levels/{levelIdFrom}/swap-with/{levelIdTo}",
+                unreleasedTrainingDefinition.getId(),
+                infoLevel1.getId(),
+                trainingLevel1.getId()))
+        .andExpect(status().isOk())
+        .andReturn()
+        .getResponse();
+    Optional<TrainingLevel> optTrainingLevel =
+        trainingLevelRepository.findById(trainingLevel1.getId());
+    Optional<InfoLevel> optInfoLevel = infoLevelRepository.findById(infoLevel1.getId());
+    assertTrue(optTrainingLevel.isPresent());
+    assertTrue(optInfoLevel.isPresent());
+    assertEquals(1, trainingLevel1.getOrder());
+    assertEquals(3, infoLevel1.getOrder());
+  }
+
+  @Test
+  public void swapLevels_FromLevelNotFound() throws Exception {
+    trainingDefinitionRepository.save(unreleasedTrainingDefinition);
+    infoLevel1.setTrainingDefinition(unreleasedTrainingDefinition);
+    infoLevel1.setOrder(1);
+    infoLevelRepository.save(infoLevel1);
+
+    MockHttpServletResponse response =
+        mvc.perform(
+                put(
+                    "/training-definitions/{definitionId}/levels/{levelIdFrom}/swap-with/{levelIdTo}",
+                    unreleasedTrainingDefinition.getId(),
+                    50,
+                    infoLevel1.getId()))
+            .andExpect(status().isNotFound())
+            .andReturn()
+            .getResponse();
+    ApiEntityError error =
+        convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
+    assertEquals(HttpStatus.NOT_FOUND, error.getStatus());
+    assertEntityDetailError(
+        error.getEntityErrorDetail(), AbstractLevel.class, "id", "50", "Level not found.");
+  }
+
+  @Test
+  public void swapLevels_ToLevelNotFound() throws Exception {
+    trainingDefinitionRepository.save(unreleasedTrainingDefinition);
+    infoLevel1.setTrainingDefinition(unreleasedTrainingDefinition);
+    infoLevel1.setOrder(1);
+    infoLevelRepository.save(infoLevel1);
+
+    MockHttpServletResponse response =
+        mvc.perform(
+                put(
+                    "/training-definitions/{definitionId}/levels/{levelIdFrom}/swap-with/{levelIdTo}",
+                    unreleasedTrainingDefinition.getId(),
+                    infoLevel1.getId(),
+                    50))
+            .andExpect(status().isNotFound())
+            .andReturn()
+            .getResponse();
+    ApiEntityError error =
+        convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
+    assertEquals(HttpStatus.NOT_FOUND, error.getStatus());
+    assertEntityDetailError(
+        error.getEntityErrorDetail(), AbstractLevel.class, "id", "50", "Level not found.");
+  }
+
+  @Test
+  public void swapLevels_CreatedInstance() throws Exception {
+    trainingDefinitionRepository.save(unreleasedTrainingDefinition);
+    trainingInstance.setTrainingDefinition(unreleasedTrainingDefinition);
+    trainingInstanceRepository.save(trainingInstance);
+    infoLevel1.setTrainingDefinition(unreleasedTrainingDefinition);
+    infoLevelRepository.save(infoLevel1);
+    trainingLevel1.setTrainingDefinition(unreleasedTrainingDefinition);
+    trainingLevelRepository.save(trainingLevel1);
+
+    MockHttpServletResponse response =
+        mvc.perform(
+                put(
+                    "/training-definitions/{definitionId}/levels/{levelIdFrom}/swap-with/{levelIdTo}",
+                    unreleasedTrainingDefinition.getId(),
+                    trainingLevel1.getId(),
+                    infoLevel1.getId()))
+            .andExpect(status().isConflict())
+            .andReturn()
+            .getResponse();
+    ApiEntityError error =
+        convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
+    assertEquals(HttpStatus.CONFLICT, error.getStatus());
+    assertEntityDetailError(
+        error.getEntityErrorDetail(),
+        TrainingDefinition.class,
+        "id",
+        unreleasedTrainingDefinition.getId().toString(),
+        "Cannot update training definition with already created training instance. Remove training instance/s before updating training definition.");
+  }
+
+  @Test
+  public void deleteTrainingDefinition() throws Exception {
+    trainingDefinitionRepository.save(unreleasedTrainingDefinition);
+    assessmentLevelWithoutQuestions.setTrainingDefinition(unreleasedTrainingDefinition);
+    trainingLevel1.setTrainingDefinition(unreleasedTrainingDefinition);
+    infoLevel1.setTrainingDefinition(unreleasedTrainingDefinition);
+    assessmentLevelRepository.save(assessmentLevelWithoutQuestions);
+    trainingLevelRepository.save(trainingLevel1);
+    infoLevelRepository.save(infoLevel1);
+
+    mvc.perform(delete("/training-definitions" + "/{id}", unreleasedTrainingDefinition.getId()))
+        .andExpect(status().isOk());
+    assertFalse(
+        trainingDefinitionRepository.findById(unreleasedTrainingDefinition.getId()).isPresent());
+    assertFalse(
+        assessmentLevelRepository.findById(assessmentLevelWithoutQuestions.getId()).isPresent());
+    assertFalse(trainingLevelRepository.findById(trainingLevel1.getId()).isPresent());
+    assertFalse(infoLevelRepository.findById(infoLevel1.getId()).isPresent());
+  }
+
+  @Test
+  public void deleteDefinition_NotFound() throws Exception {
+    MockHttpServletResponse response =
+        mvc.perform(delete("/training-definitions/{id}", 100L))
+            .andExpect(status().isNotFound())
+            .andReturn()
+            .getResponse();
+    ApiEntityError error =
+        convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
+    assertEquals(HttpStatus.NOT_FOUND, error.getStatus());
+    assertEntityDetailError(
+        error.getEntityErrorDetail(),
+        TrainingDefinition.class,
+        "id",
+        "100",
+        "Entity TrainingDefinition (id: 100) not found.");
+  }
+
+  @Test
+  public void deleteTrainingDefinition_Released() throws Exception {
+    trainingDefinitionRepository.save(releasedTrainingDefinition);
+    MockHttpServletResponse response =
+        mvc.perform(delete("/training-definitions/{Id}", releasedTrainingDefinition.getId()))
+            .andExpect(status().isConflict())
+            .andReturn()
+            .getResponse();
+    ApiEntityError error =
+        convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
+    assertEquals(HttpStatus.CONFLICT, error.getStatus());
+    assertEntityDetailError(
+        error.getEntityErrorDetail(),
+        TrainingDefinition.class,
+        "id",
+        releasedTrainingDefinition.getId().toString(),
+        "Cannot delete released training definition.");
+  }
+
+  @Test
+  public void deleteDefinition_WithTrainingInstances() throws Exception {
+    trainingDefinitionRepository.save(unreleasedTrainingDefinition);
+    trainingInstance.setTrainingDefinition(unreleasedTrainingDefinition);
+    trainingInstanceRepository.save(trainingInstance);
+
+    MockHttpServletResponse response =
+        mvc.perform(delete("/training-definitions/{id}", unreleasedTrainingDefinition.getId()))
+            .andExpect(status().isConflict())
+            .andReturn()
+            .getResponse();
+    ApiEntityError error =
+        convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
+    assertEquals(HttpStatus.CONFLICT, error.getStatus());
+    assertEntityDetailError(
+        error.getEntityErrorDetail(),
+        TrainingDefinition.class,
+        "id",
+        unreleasedTrainingDefinition.getId().toString(),
+        "Cannot delete training definition with already created training instance. Remove training instance/s before deleting training definition.");
+  }
+
+  @Test
+  public void deleteOneLevel() throws Exception {
+    trainingDefinitionRepository.save(unreleasedTrainingDefinition);
+    trainingLevelRepository.save(trainingLevel1);
+    infoLevelRepository.save(infoLevel1);
+    trainingLevel1.setTrainingDefinition(unreleasedTrainingDefinition);
+    infoLevel1.setTrainingDefinition(unreleasedTrainingDefinition);
+
+    mvc.perform(
+            delete(
+                "/training-definitions/{definitionId}/levels/{levelId}",
+                unreleasedTrainingDefinition.getId(),
+                trainingLevel1.getId()))
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON_VALUE))
+        .andExpect(status().isOk());
+
+    assertTrue(
+        trainingDefinitionRepository.findById(unreleasedTrainingDefinition.getId()).isPresent());
+    assertFalse(trainingLevelRepository.findById(trainingLevel1.getId()).isPresent());
+    assertTrue(infoLevelRepository.findById(infoLevel1.getId()).isPresent());
+  }
+
+  @Test
+  public void deleteOneLevel_NotFound() throws Exception {
+    trainingDefinitionRepository.save(unreleasedTrainingDefinition);
+    MockHttpServletResponse response =
+        mvc.perform(
+                delete(
+                    "/training-definitions/{definitionId}/levels/{levelId}",
+                    unreleasedTrainingDefinition.getId(),
+                    100L))
+            .andExpect(status().isNotFound())
+            .andReturn()
+            .getResponse();
+    ApiEntityError error =
+        convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
+    assertEquals(HttpStatus.NOT_FOUND, error.getStatus());
+    assertEntityDetailError(
+        error.getEntityErrorDetail(), AbstractLevel.class, "id", "100", "Level not found.");
+  }
+
+  @Test
+  public void deleteOneLevel_DefinitionNotFound() throws Exception {
+    trainingLevelRepository.save(trainingLevel1);
+    MockHttpServletResponse response =
+        mvc.perform(
+                delete(
+                    "/training-definitions/{definitionId}/levels/{levelId}",
+                    100L,
+                    trainingLevel1.getId()))
+            .andExpect(status().isNotFound())
+            .andReturn()
+            .getResponse();
+    ApiEntityError error =
+        convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
+    assertEquals(HttpStatus.NOT_FOUND, error.getStatus());
+    assertEntityDetailError(
+        error.getEntityErrorDetail(),
+        TrainingDefinition.class,
+        "id",
+        "100",
+        "Entity TrainingDefinition (id: 100) not found.");
+  }
+
+  @Test
+  public void deleteOneLevel_ReleasedDefinition() throws Exception {
+    trainingLevel1.setTrainingDefinition(releasedTrainingDefinition);
+    trainingDefinitionRepository.save(releasedTrainingDefinition);
+    trainingLevelRepository.save(trainingLevel1);
+    MockHttpServletResponse response =
+        mvc.perform(
+                delete(
+                    "/training-definitions/{definitionId}/levels/{levelId}",
+                    releasedTrainingDefinition.getId(),
+                    trainingLevel1.getId()))
+            .andExpect(status().isConflict())
+            .andReturn()
+            .getResponse();
+    ApiEntityError error =
+        convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
+    assertEquals(HttpStatus.CONFLICT, error.getStatus());
+    assertEntityDetailError(
+        error.getEntityErrorDetail(),
+        AbstractLevel.class,
+        "id",
+        trainingLevel1.getId().toString(),
+        "Cannot edit released or archived training definition.");
+  }
+
+  @Test
+  public void deleteOneLevel_ArchivedDefinition() throws Exception {
+    trainingDefinitionRepository.save(archivedTrainingDefinition);
+    trainingLevel1.setTrainingDefinition(archivedTrainingDefinition);
+    trainingLevelRepository.save(trainingLevel1);
+    MockHttpServletResponse response =
+        mvc.perform(
+                delete(
+                    "/training-definitions/{definitionId}/levels/{levelId}",
+                    archivedTrainingDefinition.getId(),
+                    trainingLevel1.getId()))
+            .andExpect(status().isConflict())
+            .andReturn()
+            .getResponse();
+    ApiEntityError error =
+        convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
+    assertEquals(HttpStatus.CONFLICT, error.getStatus());
+    assertEntityDetailError(
+        error.getEntityErrorDetail(),
+        AbstractLevel.class,
+        "id",
+        trainingLevel1.getId().toString(),
+        "Cannot edit released or archived training definition.");
+  }
+
+  @Test
+  public void updateTrainingLevel() throws Exception {
+    trainingDefinitionRepository.save(unreleasedTrainingDefinition);
+    trainingLevelRepository.save(trainingLevel1);
+    trainingLevel1.setTrainingDefinition(unreleasedTrainingDefinition);
+    trainingLevelUpdateDTO.setId(trainingLevel1.getId());
+
+    mvc.perform(
+            put(
+                    "/training-definitions/{definitionId}/training-levels",
+                    unreleasedTrainingDefinition.getId())
+                .content(convertObjectToJsonBytes(trainingLevelUpdateDTO))
                 .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isBadRequest())
-                .andReturn().getResolvedException();
-        assertTrue(Objects.requireNonNull(ex).getMessage().contains("Validation failed for argument"));
-        assertEquals(ex.getClass(), MethodArgumentNotValidException.class);
-    }
+        .andExpect(status().isNoContent());
 
-    @Test
-    public void updateTrainingDefinition() throws Exception {
-        trainingDefinitionRepository.save(unreleasedTrainingDefinition);
-        userRefRepository.save(author1);
-        unreleasedTrainingDefinition.addAuthor(author1);
-        trainingDefinitionUpdateDTO.setId(unreleasedTrainingDefinition.getId());
-        doReturn(buildMockResponse(organizerDTO1)).when(exchangeFunction).exchange(any(ClientRequest.class));
+    Optional<TrainingLevel> updatedTrainingLevel =
+        trainingLevelRepository.findById(trainingLevel1.getId());
+    assertTrue(updatedTrainingLevel.isPresent());
+    assertEquals(updatedTrainingLevel.get().getTitle(), trainingLevelUpdateDTO.getTitle());
+    assertEquals(updatedTrainingLevel.get().getContent(), trainingLevelUpdateDTO.getContent());
+    assertEquals(updatedTrainingLevel.get().getAnswer(), trainingLevelUpdateDTO.getAnswer());
+    assertEquals(updatedTrainingLevel.get().getSolution(), trainingLevelUpdateDTO.getSolution());
+    assertEquals(
+        updatedTrainingLevel.get().isSolutionPenalized(),
+        trainingLevelUpdateDTO.isSolutionPenalized());
+    assertEquals(updatedTrainingLevel.get().getMaxScore(), trainingLevelUpdateDTO.getMaxScore());
+  }
 
-        mvc.perform(put("/training-definitions").content(convertObjectToJsonBytes(trainingDefinitionUpdateDTO))
+  @Test
+  public void updateTrainingLevelAddNewMitreTechniques() throws Exception {
+    trainingDefinitionRepository.save(unreleasedTrainingDefinition);
+    trainingLevelRepository.save(trainingLevel1);
+    trainingLevel1.setTrainingDefinition(unreleasedTrainingDefinition);
+    trainingLevelUpdateDTO.setId(trainingLevel1.getId());
+    doReturn(buildMockResponse(authorDTO1))
+        .when(exchangeFunction)
+        .exchange(any(ClientRequest.class));
+
+    trainingLevelUpdateDTO.setMitreTechniques(List.of(mitreTechniqueDTO1, mitreTechniqueDTO2));
+
+    mvc.perform(
+            put(
+                    "/training-definitions/{definitionId}/training-levels",
+                    unreleasedTrainingDefinition.getId())
+                .content(convertObjectToJsonBytes(trainingLevelUpdateDTO))
                 .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isNoContent());
-        Optional<TrainingDefinition> optionalDefinition = trainingDefinitionRepository.findById(unreleasedTrainingDefinition.getId());
-        assertTrue(optionalDefinition.isPresent());
-        TrainingDefinition updatedDefinition = optionalDefinition.get();
-        assertEquals(trainingDefinitionUpdateDTO.getTitle(), updatedDefinition.getTitle());
-        assertEquals(trainingDefinitionUpdateDTO.getDescription(), updatedDefinition.getDescription());
-        assertEquals(trainingDefinitionUpdateDTO.getState().toString(), updatedDefinition.getState().toString());
-        assertEquals(unreleasedTrainingDefinition.getAuthors(), updatedDefinition.getAuthors());
-    }
+        .andExpect(status().isNoContent());
+    Optional<TrainingLevel> updatedTrainingLevel =
+        trainingLevelRepository.findById(trainingLevel1.getId());
+    assertTrue(updatedTrainingLevel.isPresent());
+    assertEquals(2, updatedTrainingLevel.get().getMitreTechniques().size());
+  }
 
-    @Test
-    public void updateTrainingDefinition_InvalidDefinition() throws Exception {
-        Exception ex = mvc.perform(put("/training-definitions").content(convertObjectToJsonBytes(invalidDefinitionUpdateDTO))
+  @Test
+  public void updateTrainingLevelUpdateMitreTechniques() throws Exception {
+    trainingDefinitionRepository.save(unreleasedTrainingDefinition);
+    trainingLevel1.addMitreTechnique(mitreTechnique1);
+    trainingLevel1.addMitreTechnique(mitreTechnique2);
+    trainingLevelRepository.save(trainingLevel1);
+    trainingLevel1.setTrainingDefinition(unreleasedTrainingDefinition);
+    trainingLevelUpdateDTO.setId(trainingLevel1.getId());
+    doReturn(buildMockResponse(authorDTO1))
+        .when(exchangeFunction)
+        .exchange(any(ClientRequest.class));
+
+    MitreTechniqueDTO mitreTechniqueDTO = new MitreTechniqueDTO();
+    mitreTechniqueDTO.setId(mitreTechnique1.getId());
+    mitreTechniqueDTO.setTechniqueKey(mitreTechnique1.getTechniqueKey());
+    trainingLevelUpdateDTO.setMitreTechniques(
+        List.of(mitreTechniqueDTO1, mitreTechniqueDTO2, mitreTechniqueDTO));
+
+    mvc.perform(
+            put(
+                    "/training-definitions/{definitionId}/training-levels",
+                    unreleasedTrainingDefinition.getId())
+                .content(convertObjectToJsonBytes(trainingLevelUpdateDTO))
                 .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isBadRequest())
-                .andReturn().getResolvedException();
-        assertTrue(Objects.requireNonNull(ex).getMessage().contains("Validation failed for argument"));
-        assertEquals(ex.getClass(), MethodArgumentNotValidException.class);
-    }
+        .andExpect(status().isNoContent());
 
-    @Test
-    public void updateTrainingDefinition_DefinitionNotFound() throws Exception {
-        trainingDefinitionUpdateDTO.setId(100L);
-        MockHttpServletResponse response = mvc.perform(put("/training-definitions").content(convertObjectToJsonBytes(trainingDefinitionUpdateDTO))
+    Optional<TrainingLevel> updatedTrainingLevel =
+        trainingLevelRepository.findById(trainingLevel1.getId());
+    assertTrue(updatedTrainingLevel.isPresent());
+    assertEquals(3, updatedTrainingLevel.get().getMitreTechniques().size());
+    assertFalse(updatedTrainingLevel.get().getMitreTechniques().contains(mitreTechnique2));
+    assertTrue(mitreTechnique2.getTrainingLevels().isEmpty());
+  }
+
+  @Test
+  public void updateTrainingLevelRemoveAllMitreTechniques() throws Exception {
+    trainingDefinitionRepository.save(unreleasedTrainingDefinition);
+    trainingLevel1.addMitreTechnique(mitreTechnique1);
+    trainingLevel1.addMitreTechnique(mitreTechnique2);
+    trainingLevelRepository.save(trainingLevel1);
+    trainingLevel1.setTrainingDefinition(unreleasedTrainingDefinition);
+    trainingLevelUpdateDTO.setId(trainingLevel1.getId());
+    doReturn(buildMockResponse(authorDTO1))
+        .when(exchangeFunction)
+        .exchange(any(ClientRequest.class));
+
+    mvc.perform(
+            put(
+                    "/training-definitions/{definitionId}/training-levels",
+                    unreleasedTrainingDefinition.getId())
+                .content(convertObjectToJsonBytes(trainingLevelUpdateDTO))
                 .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isNotFound())
-                .andReturn().getResponse();
-        ApiEntityError error = convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
-        assertEquals(HttpStatus.NOT_FOUND, error.getStatus());
-        assertEntityDetailError(error.getEntityErrorDetail(), TrainingDefinition.class, "id", "100",
-                "Entity TrainingDefinition (id: 100) not found.");
-    }
+        .andExpect(status().isNoContent());
 
-    @Test
-    public void updateTrainingDefinition_ReleasedDefinition() throws Exception {
-        trainingDefinitionRepository.save(releasedTrainingDefinition);
-        trainingDefinitionUpdateDTO.setId(releasedTrainingDefinition.getId());
+    Optional<TrainingLevel> updatedTrainingLevel =
+        trainingLevelRepository.findById(trainingLevel1.getId());
+    assertTrue(updatedTrainingLevel.isPresent());
+    assertEquals(0, updatedTrainingLevel.get().getMitreTechniques().size());
+    assertFalse(updatedTrainingLevel.get().getMitreTechniques().contains(mitreTechnique1));
+    assertFalse(updatedTrainingLevel.get().getMitreTechniques().contains(mitreTechnique2));
+    assertTrue(mitreTechnique1.getTrainingLevels().isEmpty());
+    assertTrue(mitreTechnique2.getTrainingLevels().isEmpty());
+  }
 
-        MockHttpServletResponse response = mvc.perform(put("/training-definitions").content(convertObjectToJsonBytes(trainingDefinitionUpdateDTO))
+  @Test
+  public void updateTrainingLevel_InvalidLevel() throws Exception {
+    Exception ex =
+        mvc.perform(
+                put("/training-definitions/{definitionId}/training-levels", 100L)
+                    .content(convertObjectToJsonBytes(invalidTrainingLevelUpdateDTO))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isBadRequest())
+            .andReturn()
+            .getResolvedException();
+    assertTrue(Objects.requireNonNull(ex).getMessage().contains("Validation failed for argument"));
+    assertEquals(ex.getClass(), MethodArgumentNotValidException.class);
+  }
+
+  @Test
+  public void updateTrainingLevel_ReleasedDefinition() throws Exception {
+    trainingDefinitionRepository.save(releasedTrainingDefinition);
+    trainingLevelRepository.save(trainingLevel1);
+    trainingLevelUpdateDTO.setId(trainingLevel1.getId());
+
+    MockHttpServletResponse response =
+        mvc.perform(
+                put(
+                        "/training-definitions/{definitionId}/training-levels",
+                        releasedTrainingDefinition.getId())
+                    .content(convertObjectToJsonBytes(trainingLevelUpdateDTO))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isConflict())
+            .andReturn()
+            .getResponse();
+    ApiEntityError error =
+        convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
+    assertEquals(HttpStatus.CONFLICT, error.getStatus());
+    assertEntityDetailError(
+        error.getEntityErrorDetail(),
+        TrainingDefinition.class,
+        "id",
+        releasedTrainingDefinition.getId().toString(),
+        "Cannot edit released or archived training definition.");
+  }
+
+  @Test
+  public void updateTrainingLevel_ArchivedDefinition() throws Exception {
+    trainingDefinitionRepository.save(archivedTrainingDefinition);
+    trainingLevelRepository.save(trainingLevel1);
+    trainingLevelUpdateDTO.setId(trainingLevel1.getId());
+
+    MockHttpServletResponse response =
+        mvc.perform(
+                put(
+                        "/training-definitions/{definitionId}/training-levels",
+                        archivedTrainingDefinition.getId())
+                    .content(convertObjectToJsonBytes(trainingLevelUpdateDTO))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isConflict())
+            .andReturn()
+            .getResponse();
+    ApiEntityError error =
+        convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
+    assertEquals(HttpStatus.CONFLICT, error.getStatus());
+    assertEntityDetailError(
+        error.getEntityErrorDetail(),
+        TrainingDefinition.class,
+        "id",
+        archivedTrainingDefinition.getId().toString(),
+        "Cannot edit released or archived training definition.");
+  }
+
+  @Test
+  public void updateTrainingLevel_DefinitionNotFound() throws Exception {
+    trainingLevelUpdateDTO.setId(1L);
+    MockHttpServletResponse response =
+        mvc.perform(
+                put("/training-definitions/{definitionId}/training-levels", 100L)
+                    .content(convertObjectToJsonBytes(trainingLevelUpdateDTO))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isNotFound())
+            .andReturn()
+            .getResponse();
+    ApiEntityError error =
+        convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
+    assertEquals(HttpStatus.NOT_FOUND, error.getStatus());
+    assertEntityDetailError(
+        error.getEntityErrorDetail(),
+        TrainingDefinition.class,
+        "id",
+        "100",
+        "Entity TrainingDefinition (id: 100) not found.");
+  }
+
+  @Test
+  public void updateTrainingLevel_NotFound() throws Exception {
+    trainingDefinitionRepository.save(unreleasedTrainingDefinition);
+    trainingLevelUpdateDTO.setId(100L);
+    MockHttpServletResponse response =
+        mvc.perform(
+                put(
+                        "/training-definitions/{definitionId}/training-levels",
+                        unreleasedTrainingDefinition.getId())
+                    .content(convertObjectToJsonBytes(trainingLevelUpdateDTO))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isNotFound())
+            .andReturn()
+            .getResponse();
+    ApiEntityError error =
+        convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
+    assertEquals(HttpStatus.NOT_FOUND, error.getStatus());
+    assertEntityDetailError(
+        error.getEntityErrorDetail(),
+        AbstractLevel.class,
+        "id",
+        trainingLevelUpdateDTO.getId().toString(),
+        "Level not found.");
+  }
+
+  @Test
+  public void updateInfoLevel() throws Exception {
+    trainingDefinitionRepository.save(unreleasedTrainingDefinition);
+    infoLevelRepository.save(infoLevel1);
+    infoLevel1.setTrainingDefinition(unreleasedTrainingDefinition);
+    infoLevelUpdateDTO.setId(infoLevel1.getId());
+
+    mvc.perform(
+            put(
+                    "/training-definitions/{definitionId}/info-levels",
+                    unreleasedTrainingDefinition.getId())
+                .content(convertObjectToJsonBytes(infoLevelUpdateDTO))
                 .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isConflict())
-                .andReturn().getResponse();
-        ApiEntityError error = convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
-        assertEquals(HttpStatus.CONFLICT, error.getStatus());
-        assertEntityDetailError(error.getEntityErrorDetail(), TrainingDefinition.class, "id", releasedTrainingDefinition.getId().toString(),
-                "Cannot edit released or archived training definition.");
-    }
+        .andExpect(status().isNoContent());
 
-    @Test
-    public void updateTrainingDefinition_CreatedInstance() throws Exception {
-        trainingDefinitionRepository.save(unreleasedTrainingDefinition);
-        trainingInstance.setTrainingDefinition(unreleasedTrainingDefinition);
-        trainingInstanceRepository.save(trainingInstance);
-        trainingDefinitionUpdateDTO.setId(unreleasedTrainingDefinition.getId());
+    Optional<InfoLevel> updatedInfoLevel = infoLevelRepository.findById(infoLevel1.getId());
+    assertTrue(updatedInfoLevel.isPresent());
+    assertEquals(updatedInfoLevel.get().getTitle(), infoLevelUpdateDTO.getTitle());
+    assertEquals(updatedInfoLevel.get().getContent(), infoLevelUpdateDTO.getContent());
+  }
 
-        MockHttpServletResponse response = mvc.perform(put("/training-definitions").content(convertObjectToJsonBytes(trainingDefinitionUpdateDTO))
+  @Test
+  public void updateInfoLevel_InvalidLevel() throws Exception {
+    Exception ex =
+        mvc.perform(
+                put("/training-definitions/{definitionId}/info-levels", 100L)
+                    .content(convertObjectToJsonBytes(invalidInfoLevelUpdateDTO))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isBadRequest())
+            .andReturn()
+            .getResolvedException();
+    assertTrue(Objects.requireNonNull(ex).getMessage().contains("Validation failed for argument"));
+    assertEquals(ex.getClass(), MethodArgumentNotValidException.class);
+  }
+
+  @Test
+  public void updateInfoLevel_ReleasedDefinition() throws Exception {
+    trainingDefinitionRepository.save(releasedTrainingDefinition);
+    infoLevelRepository.save(infoLevel1);
+    infoLevelUpdateDTO.setId(infoLevel1.getId());
+
+    MockHttpServletResponse response =
+        mvc.perform(
+                put(
+                        "/training-definitions/{definitionId}/info-levels",
+                        releasedTrainingDefinition.getId())
+                    .content(convertObjectToJsonBytes(infoLevelUpdateDTO))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isConflict())
+            .andReturn()
+            .getResponse();
+    ApiEntityError error =
+        convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
+    assertEquals(HttpStatus.CONFLICT, error.getStatus());
+    assertEntityDetailError(
+        error.getEntityErrorDetail(),
+        TrainingDefinition.class,
+        "id",
+        releasedTrainingDefinition.getId().toString(),
+        "Cannot edit released or archived training definition.");
+  }
+
+  @Test
+  public void updateInfoLevel_ArchivedDefinition() throws Exception {
+    trainingDefinitionRepository.save(archivedTrainingDefinition);
+    infoLevelRepository.save(infoLevel1);
+    infoLevelUpdateDTO.setId(infoLevel1.getId());
+
+    MockHttpServletResponse response =
+        mvc.perform(
+                put(
+                        "/training-definitions/{definitionId}/info-levels",
+                        archivedTrainingDefinition.getId())
+                    .content(convertObjectToJsonBytes(infoLevelUpdateDTO))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isConflict())
+            .andReturn()
+            .getResponse();
+    ApiEntityError error =
+        convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
+    assertEquals(HttpStatus.CONFLICT, error.getStatus());
+    assertEntityDetailError(
+        error.getEntityErrorDetail(),
+        TrainingDefinition.class,
+        "id",
+        archivedTrainingDefinition.getId().toString(),
+        "Cannot edit released or archived training definition.");
+  }
+
+  @Test
+  public void updateInfoLevel_DefinitionNotFound() throws Exception {
+    infoLevelUpdateDTO.setId(1L);
+    MockHttpServletResponse response =
+        mvc.perform(
+                put("/training-definitions/{definitionId}/info-levels", 100L)
+                    .content(convertObjectToJsonBytes(infoLevelUpdateDTO))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isNotFound())
+            .andReturn()
+            .getResponse();
+    ApiEntityError error =
+        convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
+    assertEquals(HttpStatus.NOT_FOUND, error.getStatus());
+    assertEntityDetailError(
+        error.getEntityErrorDetail(),
+        TrainingDefinition.class,
+        "id",
+        "100",
+        "Entity TrainingDefinition (id: 100) not found.");
+  }
+
+  @Test
+  public void updateInfoLevel_LevelNotFound() throws Exception {
+    trainingDefinitionRepository.save(unreleasedTrainingDefinition);
+    infoLevelUpdateDTO.setId(100L);
+    MockHttpServletResponse response =
+        mvc.perform(
+                put(
+                        "/training-definitions/{definitionId}/info-levels",
+                        unreleasedTrainingDefinition.getId())
+                    .content(convertObjectToJsonBytes(infoLevelUpdateDTO))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isNotFound())
+            .andReturn()
+            .getResponse();
+    ApiEntityError error =
+        convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
+    assertEquals(HttpStatus.NOT_FOUND, error.getStatus());
+    assertEntityDetailError(
+        error.getEntityErrorDetail(),
+        AbstractLevel.class,
+        "id",
+        infoLevelUpdateDTO.getId().toString(),
+        "Level not found.");
+  }
+
+  @Test
+  public void updateAssessmentLevelWithoutQuestions() throws Exception {
+    trainingDefinitionRepository.save(unreleasedTrainingDefinition);
+    assessmentLevelRepository.save(assessmentLevelWithoutQuestions);
+    assessmentLevelWithoutQuestions.setTrainingDefinition(unreleasedTrainingDefinition);
+    assessmentLevelUpdateDTO.setId(assessmentLevelWithoutQuestions.getId());
+    assertTrue(assessmentLevelWithoutQuestions.getQuestions().isEmpty());
+
+    mvc.perform(
+            put(
+                    "/training-definitions/{definitionId}/assessment-levels",
+                    unreleasedTrainingDefinition.getId())
+                .content(convertObjectToJsonBytes(assessmentLevelUpdateDTO))
                 .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isConflict())
-                .andReturn().getResponse();
-        ApiEntityError error = convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
-        assertEquals(HttpStatus.CONFLICT, error.getStatus());
-        assertEntityDetailError(error.getEntityErrorDetail(), TrainingDefinition.class, "id", unreleasedTrainingDefinition.getId().toString(),
-                "Cannot update training definition with already created training instance. Remove training instance/s before updating training definition.");
-    }
+        .andExpect(status().isNoContent())
+        .andReturn()
+        .getResponse();
 
-    @Test
-    public void cloneTrainingDefinition() throws Exception {
-        trainingDefinitionRepository.save(unreleasedTrainingDefinition);
-        trainingLevel1.setTrainingDefinition(unreleasedTrainingDefinition);
-        trainingLevelRepository.save(trainingLevel1);
-        mockSpringSecurityContextForGet(List.of(RoleTypeSecurity.ROLE_TRAINING_DESIGNER.name()));
-        TrainingDefinitionByIdDTO trainingDefinitionByIdDTO = trainingDefinitionMapper.mapToDTOById(unreleasedTrainingDefinition);
-        trainingDefinitionByIdDTO.setLevels(List.of(levelMapper.mapToDTO(trainingLevel1)));
+    Optional<AssessmentLevel> updatedAssessmentLevel =
+        assessmentLevelRepository.findById(assessmentLevelWithoutQuestions.getId());
+    assertTrue(updatedAssessmentLevel.isPresent());
+    assertEquals(updatedAssessmentLevel.get().getTitle(), assessmentLevelUpdateDTO.getTitle());
+    assertEquals(
+        updatedAssessmentLevel.get().getAssessmentType().toString(),
+        assessmentLevelUpdateDTO.getType().toString());
+    assertEquals(
+        assessmentLevelUpdateDTO.getQuestions().size(),
+        updatedAssessmentLevel.get().getQuestions().size());
+    assertEquals(
+        updatedAssessmentLevel.get().getInstructions(), assessmentLevelUpdateDTO.getInstructions());
+    assertEquals(
+        updatedAssessmentLevel.get().getMaxScore(),
+        assessmentLevelUpdateDTO.getQuestions().stream().mapToInt(QuestionDTO::getPoints).sum());
+    this.assertQuestionAfterUpdate(updatedAssessmentLevel.get());
+  }
 
-        MockHttpServletResponse result = mvc.perform(post("/training-definitions" + "/{id}", unreleasedTrainingDefinition.getId())
-                .param("title", "title"))
-                .andExpect(status().isOk())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON_VALUE))
-                .andReturn().getResponse();
-        Optional<TrainingDefinition> clonedTrainingDefinition = trainingDefinitionRepository.findById(2L);
-        assertTrue(clonedTrainingDefinition.isPresent());
-        assertEquals("title", clonedTrainingDefinition.get().getTitle());
-        assertEquals(clonedTrainingDefinition.get().getState().toString(), TDState.UNRELEASED.toString());
-        assertNull(clonedTrainingDefinition.get().getBetaTestingGroup());
-    }
+  @Test
+  public void updateAssessmentLevelWithQuestions() throws Exception {
+    trainingDefinitionRepository.save(unreleasedTrainingDefinition);
+    assessmentLevelWithQuestions.setTrainingDefinition(unreleasedTrainingDefinition);
+    assessmentLevelRepository.save(assessmentLevelWithQuestions);
+    assessmentLevelUpdateDTO.setId(assessmentLevelWithQuestions.getId());
+    assertFalse(assessmentLevelWithQuestions.getQuestions().isEmpty());
 
-    @Test
-    public void cloneNonexistentTrainingDefinition() throws Exception {
-        MockHttpServletResponse response = mvc.perform(post("/training-definitions" + "/{id}", 100L).param("title", "title"))
-                .andExpect(status().isNotFound())
-                .andReturn().getResponse();
-        ApiEntityError error = convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
-        assertEquals(HttpStatus.NOT_FOUND, error.getStatus());
-        assertEntityDetailError(error.getEntityErrorDetail(), TrainingDefinition.class, "id", "100",
-                "Entity TrainingDefinition (id: 100) not found.");
-    }
-
-    @Test
-    public void swapLevels() throws Exception {
-        trainingDefinitionRepository.save(unreleasedTrainingDefinition);
-        infoLevel1.setTrainingDefinition(unreleasedTrainingDefinition);
-        infoLevel1.setOrder(1);
-        trainingLevel2.setTrainingDefinition(unreleasedTrainingDefinition);
-        trainingLevel2.setOrder(2);
-        trainingLevel1.setTrainingDefinition(unreleasedTrainingDefinition);
-        trainingLevel1.setOrder(3);
-        trainingLevelRepository.saveAll(Set.of(trainingLevel1, trainingLevel2));
-        infoLevelRepository.save(infoLevel1);
-
-        mvc.perform(put("/training-definitions/{definitionId}/levels/{levelIdFrom}/swap-with/{levelIdTo}",
-                unreleasedTrainingDefinition.getId(), infoLevel1.getId(), trainingLevel1.getId()))
-                .andExpect(status().isOk())
-                .andReturn().getResponse();
-        Optional<TrainingLevel> optTrainingLevel = trainingLevelRepository.findById(trainingLevel1.getId());
-        Optional<InfoLevel> optInfoLevel = infoLevelRepository.findById(infoLevel1.getId());
-        assertTrue(optTrainingLevel.isPresent());
-        assertTrue(optInfoLevel.isPresent());
-        assertEquals(1, trainingLevel1.getOrder());
-        assertEquals(3, infoLevel1.getOrder());
-    }
-
-    @Test
-    public void swapLevels_FromLevelNotFound() throws Exception {
-        trainingDefinitionRepository.save(unreleasedTrainingDefinition);
-        infoLevel1.setTrainingDefinition(unreleasedTrainingDefinition);
-        infoLevel1.setOrder(1);
-        infoLevelRepository.save(infoLevel1);
-
-        MockHttpServletResponse response = mvc.perform(put("/training-definitions/{definitionId}/levels/{levelIdFrom}/swap-with/{levelIdTo}",
-                unreleasedTrainingDefinition.getId(), 50, infoLevel1.getId()))
-                .andExpect(status().isNotFound())
-                .andReturn().getResponse();
-        ApiEntityError error = convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
-        assertEquals(HttpStatus.NOT_FOUND, error.getStatus());
-        assertEntityDetailError(error.getEntityErrorDetail(), AbstractLevel.class, "id", "50",
-                "Level not found.");
-    }
-
-    @Test
-    public void swapLevels_ToLevelNotFound() throws Exception {
-        trainingDefinitionRepository.save(unreleasedTrainingDefinition);
-        infoLevel1.setTrainingDefinition(unreleasedTrainingDefinition);
-        infoLevel1.setOrder(1);
-        infoLevelRepository.save(infoLevel1);
-
-        MockHttpServletResponse response = mvc.perform(put("/training-definitions/{definitionId}/levels/{levelIdFrom}/swap-with/{levelIdTo}",
-                unreleasedTrainingDefinition.getId(), infoLevel1.getId(), 50))
-                .andExpect(status().isNotFound())
-                .andReturn().getResponse();
-        ApiEntityError error = convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
-        assertEquals(HttpStatus.NOT_FOUND, error.getStatus());
-        assertEntityDetailError(error.getEntityErrorDetail(), AbstractLevel.class, "id", "50",
-                "Level not found.");
-    }
-
-    @Test
-    public void swapLevels_CreatedInstance() throws Exception {
-        trainingDefinitionRepository.save(unreleasedTrainingDefinition);
-        trainingInstance.setTrainingDefinition(unreleasedTrainingDefinition);
-        trainingInstanceRepository.save(trainingInstance);
-        infoLevel1.setTrainingDefinition(unreleasedTrainingDefinition);
-        infoLevelRepository.save(infoLevel1);
-        trainingLevel1.setTrainingDefinition(unreleasedTrainingDefinition);
-        trainingLevelRepository.save(trainingLevel1);
-
-        MockHttpServletResponse response = mvc.perform(put("/training-definitions/{definitionId}/levels/{levelIdFrom}/swap-with/{levelIdTo}",
-                unreleasedTrainingDefinition.getId(), trainingLevel1.getId(), infoLevel1.getId()))
-                .andExpect(status().isConflict())
-                .andReturn().getResponse();
-        ApiEntityError error = convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
-        assertEquals(HttpStatus.CONFLICT, error.getStatus());
-        assertEntityDetailError(error.getEntityErrorDetail(), TrainingDefinition.class, "id", unreleasedTrainingDefinition.getId().toString(),
-                "Cannot update training definition with already created training instance. Remove training instance/s before updating training definition.");
-    }
-
-    @Test
-    public void deleteTrainingDefinition() throws Exception {
-        trainingDefinitionRepository.save(unreleasedTrainingDefinition);
-        assessmentLevelWithoutQuestions.setTrainingDefinition(unreleasedTrainingDefinition);
-        trainingLevel1.setTrainingDefinition(unreleasedTrainingDefinition);
-        infoLevel1.setTrainingDefinition(unreleasedTrainingDefinition);
-        assessmentLevelRepository.save(assessmentLevelWithoutQuestions);
-        trainingLevelRepository.save(trainingLevel1);
-        infoLevelRepository.save(infoLevel1);
-
-        mvc.perform(delete("/training-definitions" + "/{id}", unreleasedTrainingDefinition.getId()))
-                .andExpect(status().isOk());
-        assertFalse(trainingDefinitionRepository.findById(unreleasedTrainingDefinition.getId()).isPresent());
-        assertFalse(assessmentLevelRepository.findById(assessmentLevelWithoutQuestions.getId()).isPresent());
-        assertFalse(trainingLevelRepository.findById(trainingLevel1.getId()).isPresent());
-        assertFalse(infoLevelRepository.findById(infoLevel1.getId()).isPresent());
-    }
-
-    @Test
-    public void deleteDefinition_NotFound() throws Exception {
-        MockHttpServletResponse response = mvc.perform(delete("/training-definitions/{id}", 100L))
-                .andExpect(status().isNotFound())
-                .andReturn().getResponse();
-        ApiEntityError error = convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
-        assertEquals(HttpStatus.NOT_FOUND, error.getStatus());
-        assertEntityDetailError(error.getEntityErrorDetail(), TrainingDefinition.class, "id", "100",
-                "Entity TrainingDefinition (id: 100) not found.");
-    }
-
-    @Test
-    public void deleteTrainingDefinition_Released() throws Exception {
-        trainingDefinitionRepository.save(releasedTrainingDefinition);
-        MockHttpServletResponse response = mvc.perform(delete("/training-definitions/{Id}", releasedTrainingDefinition.getId()))
-                .andExpect(status().isConflict())
-                .andReturn().getResponse();
-        ApiEntityError error = convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
-        assertEquals(HttpStatus.CONFLICT, error.getStatus());
-        assertEntityDetailError(error.getEntityErrorDetail(), TrainingDefinition.class, "id", releasedTrainingDefinition.getId().toString(),
-                "Cannot delete released training definition.");
-    }
-
-    @Test
-    public void deleteDefinition_WithTrainingInstances() throws Exception {
-        trainingDefinitionRepository.save(unreleasedTrainingDefinition);
-        trainingInstance.setTrainingDefinition(unreleasedTrainingDefinition);
-        trainingInstanceRepository.save(trainingInstance);
-
-        MockHttpServletResponse response = mvc.perform(delete("/training-definitions/{id}", unreleasedTrainingDefinition.getId()))
-                .andExpect(status().isConflict())
-                .andReturn().getResponse();
-        ApiEntityError error = convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
-        assertEquals(HttpStatus.CONFLICT, error.getStatus());
-        assertEntityDetailError(error.getEntityErrorDetail(), TrainingDefinition.class, "id", unreleasedTrainingDefinition.getId().toString(),
-                "Cannot delete training definition with already created training instance. Remove training instance/s before deleting training definition.");
-    }
-
-    @Test
-    public void deleteOneLevel() throws Exception {
-        trainingDefinitionRepository.save(unreleasedTrainingDefinition);
-        trainingLevelRepository.save(trainingLevel1);
-        infoLevelRepository.save(infoLevel1);
-        trainingLevel1.setTrainingDefinition(unreleasedTrainingDefinition);
-        infoLevel1.setTrainingDefinition(unreleasedTrainingDefinition);
-
-        mvc.perform(delete("/training-definitions/{definitionId}/levels/{levelId}", unreleasedTrainingDefinition.getId(), trainingLevel1.getId()))
-                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isOk());
-
-        assertTrue(trainingDefinitionRepository.findById(unreleasedTrainingDefinition.getId()).isPresent());
-        assertFalse(trainingLevelRepository.findById(trainingLevel1.getId()).isPresent());
-        assertTrue(infoLevelRepository.findById(infoLevel1.getId()).isPresent());
-    }
-
-    @Test
-    public void deleteOneLevel_NotFound() throws Exception {
-        trainingDefinitionRepository.save(unreleasedTrainingDefinition);
-        MockHttpServletResponse response = mvc.perform(delete("/training-definitions/{definitionId}/levels/{levelId}", unreleasedTrainingDefinition.getId(), 100L))
-                .andExpect(status().isNotFound())
-                .andReturn().getResponse();
-        ApiEntityError error = convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
-        assertEquals(HttpStatus.NOT_FOUND, error.getStatus());
-        assertEntityDetailError(error.getEntityErrorDetail(), AbstractLevel.class, "id", "100",
-                "Level not found.");
-    }
-
-    @Test
-    public void deleteOneLevel_DefinitionNotFound() throws Exception {
-        trainingLevelRepository.save(trainingLevel1);
-        MockHttpServletResponse response = mvc.perform(delete("/training-definitions/{definitionId}/levels/{levelId}", 100L, trainingLevel1.getId()))
-                .andExpect(status().isNotFound())
-                .andReturn().getResponse();
-        ApiEntityError error = convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
-        assertEquals(HttpStatus.NOT_FOUND, error.getStatus());
-        assertEntityDetailError(error.getEntityErrorDetail(), TrainingDefinition.class, "id", "100",
-                "Entity TrainingDefinition (id: 100) not found.");
-    }
-
-    @Test
-    public void deleteOneLevel_ReleasedDefinition() throws Exception {
-        trainingLevel1.setTrainingDefinition(releasedTrainingDefinition);
-        trainingDefinitionRepository.save(releasedTrainingDefinition);
-        trainingLevelRepository.save(trainingLevel1);
-        MockHttpServletResponse response = mvc.perform(delete("/training-definitions/{definitionId}/levels/{levelId}",
-                releasedTrainingDefinition.getId(), trainingLevel1.getId()))
-                .andExpect(status().isConflict())
-                .andReturn().getResponse();
-        ApiEntityError error = convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
-        assertEquals(HttpStatus.CONFLICT, error.getStatus());
-        assertEntityDetailError(error.getEntityErrorDetail(), AbstractLevel.class, "id", trainingLevel1.getId().toString(),
-                "Cannot edit released or archived training definition.");
-    }
-
-    @Test
-    public void deleteOneLevel_ArchivedDefinition() throws Exception {
-        trainingDefinitionRepository.save(archivedTrainingDefinition);
-        trainingLevel1.setTrainingDefinition(archivedTrainingDefinition);
-        trainingLevelRepository.save(trainingLevel1);
-        MockHttpServletResponse response = mvc.perform(delete("/training-definitions/{definitionId}/levels/{levelId}",
-                archivedTrainingDefinition.getId(), trainingLevel1.getId()))
-                .andExpect(status().isConflict())
-                .andReturn().getResponse();
-        ApiEntityError error = convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
-        assertEquals(HttpStatus.CONFLICT, error.getStatus());
-        assertEntityDetailError(error.getEntityErrorDetail(), AbstractLevel.class, "id", trainingLevel1.getId().toString(),
-                "Cannot edit released or archived training definition.");
-    }
-
-    @Test
-    public void updateTrainingLevel() throws Exception {
-        trainingDefinitionRepository.save(unreleasedTrainingDefinition);
-        trainingLevelRepository.save(trainingLevel1);
-        trainingLevel1.setTrainingDefinition(unreleasedTrainingDefinition);
-        trainingLevelUpdateDTO.setId(trainingLevel1.getId());
-
-        mvc.perform(put("/training-definitions/{definitionId}/training-levels", unreleasedTrainingDefinition.getId()).content(convertObjectToJsonBytes(trainingLevelUpdateDTO))
-                .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isNoContent());
-
-        Optional<TrainingLevel> updatedTrainingLevel = trainingLevelRepository.findById(trainingLevel1.getId());
-        assertTrue(updatedTrainingLevel.isPresent());
-        assertEquals(updatedTrainingLevel.get().getTitle(), trainingLevelUpdateDTO.getTitle());
-        assertEquals(updatedTrainingLevel.get().getContent(), trainingLevelUpdateDTO.getContent());
-        assertEquals(updatedTrainingLevel.get().getAnswer(), trainingLevelUpdateDTO.getAnswer());
-        assertEquals(updatedTrainingLevel.get().getSolution(), trainingLevelUpdateDTO.getSolution());
-        assertEquals(updatedTrainingLevel.get().isSolutionPenalized(), trainingLevelUpdateDTO.isSolutionPenalized());
-        assertEquals(updatedTrainingLevel.get().getMaxScore(), trainingLevelUpdateDTO.getMaxScore());
-    }
-
-    @Test
-    public void updateTrainingLevelAddNewMitreTechniques() throws Exception {
-        trainingDefinitionRepository.save(unreleasedTrainingDefinition);
-        trainingLevelRepository.save(trainingLevel1);
-        trainingLevel1.setTrainingDefinition(unreleasedTrainingDefinition);
-        trainingLevelUpdateDTO.setId(trainingLevel1.getId());
-        doReturn(buildMockResponse(authorDTO1)).when(exchangeFunction).exchange(any(ClientRequest.class));
-
-        trainingLevelUpdateDTO.setMitreTechniques(List.of(mitreTechniqueDTO1, mitreTechniqueDTO2));
-
-        mvc.perform(put("/training-definitions/{definitionId}/training-levels", unreleasedTrainingDefinition.getId()).content(convertObjectToJsonBytes(trainingLevelUpdateDTO))
-                .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isNoContent());
-        Optional<TrainingLevel> updatedTrainingLevel = trainingLevelRepository.findById(trainingLevel1.getId());
-        assertTrue(updatedTrainingLevel.isPresent());
-        assertEquals(2, updatedTrainingLevel.get().getMitreTechniques().size());
-    }
-
-    @Test
-    public void updateTrainingLevelUpdateMitreTechniques() throws Exception {
-        trainingDefinitionRepository.save(unreleasedTrainingDefinition);
-        trainingLevel1.addMitreTechnique(mitreTechnique1);
-        trainingLevel1.addMitreTechnique(mitreTechnique2);
-        trainingLevelRepository.save(trainingLevel1);
-        trainingLevel1.setTrainingDefinition(unreleasedTrainingDefinition);
-        trainingLevelUpdateDTO.setId(trainingLevel1.getId());
-        doReturn(buildMockResponse(authorDTO1)).when(exchangeFunction).exchange(any(ClientRequest.class));
-
-        MitreTechniqueDTO mitreTechniqueDTO = new MitreTechniqueDTO();
-        mitreTechniqueDTO.setId(mitreTechnique1.getId());
-        mitreTechniqueDTO.setTechniqueKey(mitreTechnique1.getTechniqueKey());
-        trainingLevelUpdateDTO.setMitreTechniques(List.of(mitreTechniqueDTO1, mitreTechniqueDTO2, mitreTechniqueDTO));
-
-        mvc.perform(put("/training-definitions/{definitionId}/training-levels", unreleasedTrainingDefinition.getId()).content(convertObjectToJsonBytes(trainingLevelUpdateDTO))
-                .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isNoContent());
-
-        Optional<TrainingLevel> updatedTrainingLevel = trainingLevelRepository.findById(trainingLevel1.getId());
-        assertTrue(updatedTrainingLevel.isPresent());
-        assertEquals(3, updatedTrainingLevel.get().getMitreTechniques().size());
-        assertFalse(updatedTrainingLevel.get().getMitreTechniques().contains(mitreTechnique2));
-        assertTrue(mitreTechnique2.getTrainingLevels().isEmpty());
-    }
-
-    @Test
-    public void updateTrainingLevelRemoveAllMitreTechniques() throws Exception {
-        trainingDefinitionRepository.save(unreleasedTrainingDefinition);
-        trainingLevel1.addMitreTechnique(mitreTechnique1);
-        trainingLevel1.addMitreTechnique(mitreTechnique2);
-        trainingLevelRepository.save(trainingLevel1);
-        trainingLevel1.setTrainingDefinition(unreleasedTrainingDefinition);
-        trainingLevelUpdateDTO.setId(trainingLevel1.getId());
-        doReturn(buildMockResponse(authorDTO1)).when(exchangeFunction).exchange(any(ClientRequest.class));
-
-        mvc.perform(put("/training-definitions/{definitionId}/training-levels", unreleasedTrainingDefinition.getId()).content(convertObjectToJsonBytes(trainingLevelUpdateDTO))
-                .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isNoContent());
-
-        Optional<TrainingLevel> updatedTrainingLevel = trainingLevelRepository.findById(trainingLevel1.getId());
-        assertTrue(updatedTrainingLevel.isPresent());
-        assertEquals(0, updatedTrainingLevel.get().getMitreTechniques().size());
-        assertFalse(updatedTrainingLevel.get().getMitreTechniques().contains(mitreTechnique1));
-        assertFalse(updatedTrainingLevel.get().getMitreTechniques().contains(mitreTechnique2));
-        assertTrue(mitreTechnique1.getTrainingLevels().isEmpty());
-        assertTrue(mitreTechnique2.getTrainingLevels().isEmpty());
-    }
-
-    @Test
-    public void updateTrainingLevel_InvalidLevel() throws Exception {
-        Exception ex = mvc.perform(put("/training-definitions/{definitionId}/training-levels", 100L).content(convertObjectToJsonBytes(invalidTrainingLevelUpdateDTO))
-                .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isBadRequest())
-                .andReturn().getResolvedException();
-        assertTrue(Objects.requireNonNull(ex).getMessage().contains("Validation failed for argument"));
-        assertEquals(ex.getClass(), MethodArgumentNotValidException.class);
-    }
-
-    @Test
-    public void updateTrainingLevel_ReleasedDefinition() throws Exception {
-        trainingDefinitionRepository.save(releasedTrainingDefinition);
-        trainingLevelRepository.save(trainingLevel1);
-        trainingLevelUpdateDTO.setId(trainingLevel1.getId());
-
-        MockHttpServletResponse response = mvc.perform(put("/training-definitions/{definitionId}/training-levels",
-                releasedTrainingDefinition.getId()).content(convertObjectToJsonBytes(trainingLevelUpdateDTO))
-                .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isConflict())
-                .andReturn().getResponse();
-        ApiEntityError error = convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
-        assertEquals(HttpStatus.CONFLICT, error.getStatus());
-        assertEntityDetailError(error.getEntityErrorDetail(), TrainingDefinition.class, "id", releasedTrainingDefinition.getId().toString(),
-                "Cannot edit released or archived training definition.");
-    }
-
-    @Test
-    public void updateTrainingLevel_ArchivedDefinition() throws Exception {
-        trainingDefinitionRepository.save(archivedTrainingDefinition);
-        trainingLevelRepository.save(trainingLevel1);
-        trainingLevelUpdateDTO.setId(trainingLevel1.getId());
-
-        MockHttpServletResponse response = mvc.perform(put("/training-definitions/{definitionId}/training-levels", archivedTrainingDefinition.getId()).content(convertObjectToJsonBytes(trainingLevelUpdateDTO))
-                .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isConflict())
-                .andReturn().getResponse();
-        ApiEntityError error = convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
-        assertEquals(HttpStatus.CONFLICT, error.getStatus());
-        assertEntityDetailError(error.getEntityErrorDetail(), TrainingDefinition.class, "id", archivedTrainingDefinition.getId().toString(),
-                "Cannot edit released or archived training definition.");
-    }
-
-    @Test
-    public void updateTrainingLevel_DefinitionNotFound() throws Exception {
-        trainingLevelUpdateDTO.setId(1L);
-        MockHttpServletResponse response = mvc.perform(put("/training-definitions/{definitionId}/training-levels", 100L).content(convertObjectToJsonBytes(trainingLevelUpdateDTO))
-                .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isNotFound())
-                .andReturn().getResponse();
-        ApiEntityError error = convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
-        assertEquals(HttpStatus.NOT_FOUND, error.getStatus());
-        assertEntityDetailError(error.getEntityErrorDetail(), TrainingDefinition.class, "id", "100",
-                "Entity TrainingDefinition (id: 100) not found.");
-    }
-
-    @Test
-    public void updateTrainingLevel_NotFound() throws Exception {
-        trainingDefinitionRepository.save(unreleasedTrainingDefinition);
-        trainingLevelUpdateDTO.setId(100L);
-        MockHttpServletResponse response = mvc.perform(put("/training-definitions/{definitionId}/training-levels",
-                unreleasedTrainingDefinition.getId()).content(convertObjectToJsonBytes(trainingLevelUpdateDTO))
-                .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isNotFound())
-                .andReturn().getResponse();
-        ApiEntityError error = convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
-        assertEquals(HttpStatus.NOT_FOUND, error.getStatus());
-        assertEntityDetailError(error.getEntityErrorDetail(), AbstractLevel.class, "id", trainingLevelUpdateDTO.getId().toString(),
-                "Level not found.");
-    }
-
-    @Test
-    public void updateInfoLevel() throws Exception {
-        trainingDefinitionRepository.save(unreleasedTrainingDefinition);
-        infoLevelRepository.save(infoLevel1);
-        infoLevel1.setTrainingDefinition(unreleasedTrainingDefinition);
-        infoLevelUpdateDTO.setId(infoLevel1.getId());
-
-        mvc.perform(put("/training-definitions/{definitionId}/info-levels", unreleasedTrainingDefinition.getId()).content(convertObjectToJsonBytes(infoLevelUpdateDTO))
-                .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isNoContent());
-
-        Optional<InfoLevel> updatedInfoLevel = infoLevelRepository.findById(infoLevel1.getId());
-        assertTrue(updatedInfoLevel.isPresent());
-        assertEquals(updatedInfoLevel.get().getTitle(), infoLevelUpdateDTO.getTitle());
-        assertEquals(updatedInfoLevel.get().getContent(), infoLevelUpdateDTO.getContent());
-    }
-
-    @Test
-    public void updateInfoLevel_InvalidLevel() throws Exception {
-        Exception ex = mvc.perform(put("/training-definitions/{definitionId}/info-levels", 100L).content(convertObjectToJsonBytes(invalidInfoLevelUpdateDTO))
-                .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isBadRequest())
-                .andReturn().getResolvedException();
-        assertTrue(Objects.requireNonNull(ex).getMessage().contains("Validation failed for argument"));
-        assertEquals(ex.getClass(), MethodArgumentNotValidException.class);
-    }
-
-    @Test
-    public void updateInfoLevel_ReleasedDefinition() throws Exception {
-        trainingDefinitionRepository.save(releasedTrainingDefinition);
-        infoLevelRepository.save(infoLevel1);
-        infoLevelUpdateDTO.setId(infoLevel1.getId());
-
-        MockHttpServletResponse response = mvc.perform(put("/training-definitions/{definitionId}/info-levels", releasedTrainingDefinition.getId()).content(convertObjectToJsonBytes(infoLevelUpdateDTO))
-                .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isConflict())
-                .andReturn().getResponse();
-        ApiEntityError error = convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
-        assertEquals(HttpStatus.CONFLICT, error.getStatus());
-        assertEntityDetailError(error.getEntityErrorDetail(), TrainingDefinition.class, "id", releasedTrainingDefinition.getId().toString(),
-                "Cannot edit released or archived training definition.");
-    }
-
-    @Test
-    public void updateInfoLevel_ArchivedDefinition() throws Exception {
-        trainingDefinitionRepository.save(archivedTrainingDefinition);
-        infoLevelRepository.save(infoLevel1);
-        infoLevelUpdateDTO.setId(infoLevel1.getId());
-
-        MockHttpServletResponse response = mvc.perform(put("/training-definitions/{definitionId}/info-levels",
-                archivedTrainingDefinition.getId()).content(convertObjectToJsonBytes(infoLevelUpdateDTO))
-                .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isConflict())
-                .andReturn().getResponse();
-        ApiEntityError error = convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
-        assertEquals(HttpStatus.CONFLICT, error.getStatus());
-        assertEntityDetailError(error.getEntityErrorDetail(), TrainingDefinition.class, "id", archivedTrainingDefinition.getId().toString(),
-                "Cannot edit released or archived training definition.");
-    }
-
-    @Test
-    public void updateInfoLevel_DefinitionNotFound() throws Exception {
-        infoLevelUpdateDTO.setId(1L);
-        MockHttpServletResponse response = mvc.perform(put("/training-definitions/{definitionId}/info-levels", 100L).content(convertObjectToJsonBytes(infoLevelUpdateDTO))
-                .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isNotFound())
-                .andReturn().getResponse();
-        ApiEntityError error = convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
-        assertEquals(HttpStatus.NOT_FOUND, error.getStatus());
-        assertEntityDetailError(error.getEntityErrorDetail(), TrainingDefinition.class, "id", "100",
-                "Entity TrainingDefinition (id: 100) not found.");
-    }
-
-    @Test
-    public void updateInfoLevel_LevelNotFound() throws Exception {
-        trainingDefinitionRepository.save(unreleasedTrainingDefinition);
-        infoLevelUpdateDTO.setId(100L);
-        MockHttpServletResponse response = mvc.perform(put("/training-definitions/{definitionId}/info-levels",
-                unreleasedTrainingDefinition.getId()).content(convertObjectToJsonBytes(infoLevelUpdateDTO))
-                .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isNotFound())
-                .andReturn().getResponse();
-        ApiEntityError error = convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
-        assertEquals(HttpStatus.NOT_FOUND, error.getStatus());
-        assertEntityDetailError(error.getEntityErrorDetail(), AbstractLevel.class, "id", infoLevelUpdateDTO.getId().toString(),
-                "Level not found.");
-
-    }
-
-    @Test
-    public void updateAssessmentLevelWithoutQuestions() throws Exception {
-        trainingDefinitionRepository.save(unreleasedTrainingDefinition);
-        assessmentLevelRepository.save(assessmentLevelWithoutQuestions);
-        assessmentLevelWithoutQuestions.setTrainingDefinition(unreleasedTrainingDefinition);
-        assessmentLevelUpdateDTO.setId(assessmentLevelWithoutQuestions.getId());
-        assertTrue(assessmentLevelWithoutQuestions.getQuestions().isEmpty());
-
-        mvc.perform(put("/training-definitions/{definitionId}/assessment-levels",
-                unreleasedTrainingDefinition.getId()).content(convertObjectToJsonBytes(assessmentLevelUpdateDTO))
-                .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isNoContent())
-                .andReturn().getResponse();
-
-        Optional<AssessmentLevel> updatedAssessmentLevel = assessmentLevelRepository.findById(assessmentLevelWithoutQuestions.getId());
-        assertTrue(updatedAssessmentLevel.isPresent());
-        assertEquals(updatedAssessmentLevel.get().getTitle(), assessmentLevelUpdateDTO.getTitle());
-        assertEquals(updatedAssessmentLevel.get().getAssessmentType().toString(), assessmentLevelUpdateDTO.getType().toString());
-        assertEquals(assessmentLevelUpdateDTO.getQuestions().size(), updatedAssessmentLevel.get().getQuestions().size());
-        assertEquals(updatedAssessmentLevel.get().getInstructions(), assessmentLevelUpdateDTO.getInstructions());
-        assertEquals(updatedAssessmentLevel.get().getMaxScore(), assessmentLevelUpdateDTO.getQuestions().stream().mapToInt(QuestionDTO::getPoints).sum());
-        this.assertQuestionAfterUpdate(updatedAssessmentLevel.get());
-    }
-
-    @Test
-    public void updateAssessmentLevelWithQuestions() throws Exception {
-        trainingDefinitionRepository.save(unreleasedTrainingDefinition);
-        assessmentLevelWithQuestions.setTrainingDefinition(unreleasedTrainingDefinition);
-        assessmentLevelRepository.save(assessmentLevelWithQuestions);
-        assessmentLevelUpdateDTO.setId(assessmentLevelWithQuestions.getId());
-        assertFalse(assessmentLevelWithQuestions.getQuestions().isEmpty());
-
-        assessmentLevelWithQuestions.getQuestions().forEach(question -> {
-            if (question.getQuestionType() == cz.cyberrange.platform.training.persistence.model.enums.QuestionType.FFQ) {
+    assessmentLevelWithQuestions
+        .getQuestions()
+        .forEach(
+            question -> {
+              if (question.getQuestionType()
+                  == cz.cyberrange.platform.training.persistence.model.enums.QuestionType.FFQ) {
                 assertEquals(3, question.getChoices().size());
-            } else if (question.getQuestionType() == cz.cyberrange.platform.training.persistence.model.enums.QuestionType.MCQ) {
+              } else if (question.getQuestionType()
+                  == cz.cyberrange.platform.training.persistence.model.enums.QuestionType.MCQ) {
                 assertEquals(3, question.getChoices().size());
-            } else if (question.getQuestionType() == cz.cyberrange.platform.training.persistence.model.enums.QuestionType.EMI) {
+              } else if (question.getQuestionType()
+                  == cz.cyberrange.platform.training.persistence.model.enums.QuestionType.EMI) {
                 assertEquals(4, question.getExtendedMatchingOptions().size());
                 assertEquals(3, question.getExtendedMatchingStatements().size());
                 question.getExtendedMatchingStatements().forEach(Assertions::assertNotNull);
-            }
-        });
+              }
+            });
 
-        mvc.perform(put("/training-definitions/{definitionId}/assessment-levels",
-                unreleasedTrainingDefinition.getId()).content(convertObjectToJsonBytes(assessmentLevelUpdateDTO))
+    mvc.perform(
+            put(
+                    "/training-definitions/{definitionId}/assessment-levels",
+                    unreleasedTrainingDefinition.getId())
+                .content(convertObjectToJsonBytes(assessmentLevelUpdateDTO))
                 .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isNoContent())
-                .andReturn().getResponse();
+        .andExpect(status().isNoContent())
+        .andReturn()
+        .getResponse();
 
-        Optional<AssessmentLevel> updatedAssessmentLevel = assessmentLevelRepository.findById(assessmentLevelWithQuestions.getId());
-        assertTrue(updatedAssessmentLevel.isPresent());
-        assertEquals(updatedAssessmentLevel.get().getTitle(), assessmentLevelUpdateDTO.getTitle());
-        assertEquals(updatedAssessmentLevel.get().getAssessmentType().toString(), assessmentLevelUpdateDTO.getType().toString());
-        assertEquals(assessmentLevelUpdateDTO.getQuestions().size(), updatedAssessmentLevel.get().getQuestions().size());
-        assertEquals(updatedAssessmentLevel.get().getInstructions(), assessmentLevelUpdateDTO.getInstructions());
-        assertEquals(updatedAssessmentLevel.get().getMaxScore(), assessmentLevelUpdateDTO.getQuestions().stream().mapToInt(QuestionDTO::getPoints).sum());
-        this.assertQuestionAfterUpdate(updatedAssessmentLevel.get());
-    }
+    Optional<AssessmentLevel> updatedAssessmentLevel =
+        assessmentLevelRepository.findById(assessmentLevelWithQuestions.getId());
+    assertTrue(updatedAssessmentLevel.isPresent());
+    assertEquals(updatedAssessmentLevel.get().getTitle(), assessmentLevelUpdateDTO.getTitle());
+    assertEquals(
+        updatedAssessmentLevel.get().getAssessmentType().toString(),
+        assessmentLevelUpdateDTO.getType().toString());
+    assertEquals(
+        assessmentLevelUpdateDTO.getQuestions().size(),
+        updatedAssessmentLevel.get().getQuestions().size());
+    assertEquals(
+        updatedAssessmentLevel.get().getInstructions(), assessmentLevelUpdateDTO.getInstructions());
+    assertEquals(
+        updatedAssessmentLevel.get().getMaxScore(),
+        assessmentLevelUpdateDTO.getQuestions().stream().mapToInt(QuestionDTO::getPoints).sum());
+    this.assertQuestionAfterUpdate(updatedAssessmentLevel.get());
+  }
 
-    @Test
-    public void updateAssessmentLevel_InvalidLevel() throws Exception {
-        Exception ex = mvc.perform(put("/training-definitions/{definitionId}/assessment-levels", 100L).content(convertObjectToJsonBytes(invalidAssessmentLevelUpdateDTO))
-                .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isBadRequest())
-                .andReturn().getResolvedException();
-        assertTrue(Objects.requireNonNull(ex).getMessage().contains("Validation failed for argument"));
-        assertEquals(ex.getClass(), MethodArgumentNotValidException.class);
-    }
+  @Test
+  public void updateAssessmentLevel_InvalidLevel() throws Exception {
+    Exception ex =
+        mvc.perform(
+                put("/training-definitions/{definitionId}/assessment-levels", 100L)
+                    .content(convertObjectToJsonBytes(invalidAssessmentLevelUpdateDTO))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isBadRequest())
+            .andReturn()
+            .getResolvedException();
+    assertTrue(Objects.requireNonNull(ex).getMessage().contains("Validation failed for argument"));
+    assertEquals(ex.getClass(), MethodArgumentNotValidException.class);
+  }
 
-    @Test
-    public void updateAssessmentLevel_ReleasedDefinition() throws Exception {
-        trainingDefinitionRepository.save(releasedTrainingDefinition);
-        assessmentLevelRepository.save(assessmentLevelWithoutQuestions);
-        assessmentLevelUpdateDTO.setId(assessmentLevelWithoutQuestions.getId());
+  @Test
+  public void updateAssessmentLevel_ReleasedDefinition() throws Exception {
+    trainingDefinitionRepository.save(releasedTrainingDefinition);
+    assessmentLevelRepository.save(assessmentLevelWithoutQuestions);
+    assessmentLevelUpdateDTO.setId(assessmentLevelWithoutQuestions.getId());
 
-        MockHttpServletResponse response = mvc.perform(put("/training-definitions/{definitionId}/assessment-levels", releasedTrainingDefinition.getId()).content(convertObjectToJsonBytes(assessmentLevelUpdateDTO))
-                .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isConflict())
-                .andReturn().getResponse();
-        ApiEntityError error = convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
-        assertEquals(HttpStatus.CONFLICT, error.getStatus());
-        assertEntityDetailError(error.getEntityErrorDetail(), TrainingDefinition.class, "id", releasedTrainingDefinition.getId().toString(),
-                "Cannot edit released or archived training definition.");
-    }
+    MockHttpServletResponse response =
+        mvc.perform(
+                put(
+                        "/training-definitions/{definitionId}/assessment-levels",
+                        releasedTrainingDefinition.getId())
+                    .content(convertObjectToJsonBytes(assessmentLevelUpdateDTO))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isConflict())
+            .andReturn()
+            .getResponse();
+    ApiEntityError error =
+        convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
+    assertEquals(HttpStatus.CONFLICT, error.getStatus());
+    assertEntityDetailError(
+        error.getEntityErrorDetail(),
+        TrainingDefinition.class,
+        "id",
+        releasedTrainingDefinition.getId().toString(),
+        "Cannot edit released or archived training definition.");
+  }
 
-    @Test
-    public void updateAssessmentLevel_ArchivedDefinition() throws Exception {
-        trainingDefinitionRepository.save(archivedTrainingDefinition);
-        assessmentLevelRepository.save(assessmentLevelWithoutQuestions);
-        assessmentLevelUpdateDTO.setId(assessmentLevelWithoutQuestions.getId());
+  @Test
+  public void updateAssessmentLevel_ArchivedDefinition() throws Exception {
+    trainingDefinitionRepository.save(archivedTrainingDefinition);
+    assessmentLevelRepository.save(assessmentLevelWithoutQuestions);
+    assessmentLevelUpdateDTO.setId(assessmentLevelWithoutQuestions.getId());
 
-        MockHttpServletResponse response = mvc.perform(put("/training-definitions/{definitionId}/assessment-levels",
-                archivedTrainingDefinition.getId()).content(convertObjectToJsonBytes(assessmentLevelUpdateDTO))
-                .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isConflict())
-                .andReturn().getResponse();
-        ApiEntityError error = convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
-        assertEquals(HttpStatus.CONFLICT, error.getStatus());
-        assertEntityDetailError(error.getEntityErrorDetail(), TrainingDefinition.class, "id", archivedTrainingDefinition.getId().toString(),
-                "Cannot edit released or archived training definition.");
-    }
+    MockHttpServletResponse response =
+        mvc.perform(
+                put(
+                        "/training-definitions/{definitionId}/assessment-levels",
+                        archivedTrainingDefinition.getId())
+                    .content(convertObjectToJsonBytes(assessmentLevelUpdateDTO))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isConflict())
+            .andReturn()
+            .getResponse();
+    ApiEntityError error =
+        convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
+    assertEquals(HttpStatus.CONFLICT, error.getStatus());
+    assertEntityDetailError(
+        error.getEntityErrorDetail(),
+        TrainingDefinition.class,
+        "id",
+        archivedTrainingDefinition.getId().toString(),
+        "Cannot edit released or archived training definition.");
+  }
 
-    @Test
-    public void updateAssessmentLevel_DefinitionNotFound() throws Exception {
-        assessmentLevelUpdateDTO.setId(1L);
-        MockHttpServletResponse response = mvc.perform(put("/training-definitions/{definitionId}/assessment-levels", 100L).content(convertObjectToJsonBytes(assessmentLevelUpdateDTO))
-                .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isNotFound())
-                .andReturn().getResponse();
-        ApiEntityError error = convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
-        assertEquals(HttpStatus.NOT_FOUND, error.getStatus());
-        assertEntityDetailError(error.getEntityErrorDetail(), TrainingDefinition.class, "id", "100",
-                "Entity TrainingDefinition (id: 100) not found.");
-    }
+  @Test
+  public void updateAssessmentLevel_DefinitionNotFound() throws Exception {
+    assessmentLevelUpdateDTO.setId(1L);
+    MockHttpServletResponse response =
+        mvc.perform(
+                put("/training-definitions/{definitionId}/assessment-levels", 100L)
+                    .content(convertObjectToJsonBytes(assessmentLevelUpdateDTO))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isNotFound())
+            .andReturn()
+            .getResponse();
+    ApiEntityError error =
+        convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
+    assertEquals(HttpStatus.NOT_FOUND, error.getStatus());
+    assertEntityDetailError(
+        error.getEntityErrorDetail(),
+        TrainingDefinition.class,
+        "id",
+        "100",
+        "Entity TrainingDefinition (id: 100) not found.");
+  }
 
-    @Test
-    public void updateAssessmentLevel_LevelNotFound() throws Exception {
+  @Test
+  public void updateAssessmentLevel_LevelNotFound() throws Exception {
+    trainingDefinitionRepository.save(unreleasedTrainingDefinition);
+    assessmentLevelUpdateDTO.setId(100L);
+    MockHttpServletResponse response =
+        mvc.perform(
+                put(
+                        "/training-definitions/{definitionId}/assessment-levels",
+                        unreleasedTrainingDefinition.getId())
+                    .content(convertObjectToJsonBytes(assessmentLevelUpdateDTO))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isNotFound())
+            .andReturn()
+            .getResponse();
+    ApiEntityError error =
+        convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
+    assertEquals(HttpStatus.NOT_FOUND, error.getStatus());
+    assertEntityDetailError(
+        error.getEntityErrorDetail(),
+        AbstractLevel.class,
+        "id",
+        assessmentLevelUpdateDTO.getId().toString(),
+        "Level not found.");
+  }
+
+  @Test
+  public void findTrainingLevelById() throws Exception {
+    trainingDefinitionRepository.save(unreleasedTrainingDefinition);
+    trainingLevel1.setTrainingDefinition(unreleasedTrainingDefinition);
+    trainingLevelRepository.save(trainingLevel1);
+    MockHttpServletResponse result =
+        mvc.perform(get("/training-definitions/levels/{id}", trainingLevel1.getId()))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andReturn()
+            .getResponse();
+    TrainingLevelDTO trainingLevelDTO = levelMapper.mapToTrainingLevelDTO(trainingLevel1);
+    trainingLevelDTO.setLevelType(LevelType.TRAINING_LEVEL);
+    assertEquals(
+        trainingLevelDTO,
+        convertJsonBytesToObject(
+            convertJsonBytesToObject(result.getContentAsString()), TrainingLevelDTO.class));
+  }
+
+  @Test
+  public void findInfoLevelById() throws Exception {
+    trainingDefinitionRepository.save(unreleasedTrainingDefinition);
+    infoLevel1.setTrainingDefinition(unreleasedTrainingDefinition);
+    infoLevelRepository.save(infoLevel1);
+    MockHttpServletResponse result =
+        mvc.perform(get("/training-definitions/levels/{id}", infoLevel1.getId()))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andReturn()
+            .getResponse();
+    InfoLevelDTO infoLevelDTO = levelMapper.mapToInfoLevelDTO(infoLevel1);
+    infoLevelDTO.setLevelType(LevelType.INFO_LEVEL);
+    assertEquals(
+        infoLevelDTO,
+        convertJsonBytesToObject(
+            convertJsonBytesToObject(result.getContentAsString()), InfoLevelDTO.class));
+  }
+
+  @Test
+  public void findAssessmentLevelById() throws Exception {
+    trainingDefinitionRepository.save(unreleasedTrainingDefinition);
+    assessmentLevelWithoutQuestions.setTrainingDefinition(unreleasedTrainingDefinition);
+    assessmentLevelRepository.save(assessmentLevelWithoutQuestions);
+    MockHttpServletResponse result =
+        mvc.perform(
+                get("/training-definitions/levels/{id}", assessmentLevelWithoutQuestions.getId()))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andReturn()
+            .getResponse();
+    AssessmentLevelDTO assessmentLevelDTO =
+        levelMapper.mapToAssessmentLevelDTO(assessmentLevelWithoutQuestions);
+    assessmentLevelDTO.setLevelType(LevelType.ASSESSMENT_LEVEL);
+    assertEquals(
+        assessmentLevelDTO,
+        convertJsonBytesToObject(
+            convertJsonBytesToObject(result.getContentAsString()), AssessmentLevelDTO.class));
+  }
+
+  @Test
+  public void findTrainingLevelById_NotFound() throws Exception {
+    MockHttpServletResponse response =
+        mvc.perform(get("/training-definitions/levels/{id}", 100L))
+            .andExpect(status().isNotFound())
+            .andReturn()
+            .getResponse();
+    ApiEntityError error =
+        convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
+    assertEquals(HttpStatus.NOT_FOUND, error.getStatus());
+    assertEntityDetailError(
+        error.getEntityErrorDetail(), AbstractLevel.class, "id", "100", "Level not found.");
+  }
+
+  @Test
+  public void createTrainingLevel() throws Exception {
+    TrainingDefinition trainingDefinition =
         trainingDefinitionRepository.save(unreleasedTrainingDefinition);
-        assessmentLevelUpdateDTO.setId(100L);
-        MockHttpServletResponse response = mvc.perform(put("/training-definitions/{definitionId}/assessment-levels", unreleasedTrainingDefinition.getId()).content(convertObjectToJsonBytes(assessmentLevelUpdateDTO))
-                .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isNotFound())
-                .andReturn().getResponse();
-        ApiEntityError error = convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
-        assertEquals(HttpStatus.NOT_FOUND, error.getStatus());
-        assertEntityDetailError(error.getEntityErrorDetail(), AbstractLevel.class, "id", assessmentLevelUpdateDTO.getId().toString(),
-                "Level not found.");
-    }
+    MockHttpServletResponse response =
+        mvc.perform(
+                post(
+                    "/training-definitions/{definitionId}/levels/{levelType}",
+                    trainingDefinition.getId(),
+                    cz.cyberrange.platform.training.persistence.model.enums.LevelType.TRAINING))
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isCreated())
+            .andReturn()
+            .getResponse();
 
-    @Test
-    public void findTrainingLevelById() throws Exception {
+    BasicLevelInfoDTO levelInfoDTO =
+        convertJsonBytesToObject(
+            convertJsonBytesToObject(response.getContentAsString()), BasicLevelInfoDTO.class);
+    Optional<TrainingLevel> optionalTrainingLevel =
+        trainingLevelRepository.findById(levelInfoDTO.getId());
+    assertTrue(optionalTrainingLevel.isPresent());
+    TrainingLevel trainingLevel = optionalTrainingLevel.get();
+    assertEquals(100, trainingLevel.getMaxScore());
+    assertEquals("Title of training level", trainingLevel.getTitle());
+    assertEquals(100, trainingLevel.getIncorrectAnswerLimit());
+    assertEquals("Secret answer", trainingLevel.getAnswer());
+    assertTrue(trainingLevel.isSolutionPenalized());
+    assertEquals("Solution of the training should be here", trainingLevel.getSolution());
+    assertEquals("The test entry should be here", trainingLevel.getContent());
+  }
+
+  @Test
+  public void createInfoLevel() throws Exception {
+    TrainingDefinition trainingDefinition =
         trainingDefinitionRepository.save(unreleasedTrainingDefinition);
-        trainingLevel1.setTrainingDefinition(unreleasedTrainingDefinition);
-        trainingLevelRepository.save(trainingLevel1);
-        MockHttpServletResponse result = mvc.perform(get("/training-definitions/levels/{id}", trainingLevel1.getId()))
-                .andExpect(status().isOk())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andReturn().getResponse();
-        TrainingLevelDTO trainingLevelDTO = levelMapper.mapToTrainingLevelDTO(trainingLevel1);
-        trainingLevelDTO.setLevelType(LevelType.TRAINING_LEVEL);
-        assertEquals(trainingLevelDTO, convertJsonBytesToObject(convertJsonBytesToObject(result.getContentAsString()), TrainingLevelDTO.class));
-    }
+    MockHttpServletResponse response =
+        mvc.perform(
+                post(
+                    "/training-definitions/{definitionId}/levels/{levelType}",
+                    trainingDefinition.getId(),
+                    cz.cyberrange.platform.training.persistence.model.enums.LevelType.INFO))
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isCreated())
+            .andReturn()
+            .getResponse();
 
-    @Test
-    public void findInfoLevelById() throws Exception {
+    BasicLevelInfoDTO levelInfoDTO =
+        convertJsonBytesToObject(
+            convertJsonBytesToObject(response.getContentAsString()), BasicLevelInfoDTO.class);
+    Optional<InfoLevel> optionalInfoLevel = infoLevelRepository.findById(levelInfoDTO.getId());
+    assertTrue(optionalInfoLevel.isPresent());
+    InfoLevel infoLevel = optionalInfoLevel.get();
+    assertEquals(0, infoLevel.getMaxScore());
+    assertEquals("Title of info level", infoLevel.getTitle());
+    assertEquals("Content of info level should be here.", infoLevel.getContent());
+  }
+
+  @Test
+  public void createAssessmentLevel() throws Exception {
+    mapper.setPropertyNamingStrategy(new PropertyNamingStrategies.SnakeCaseStrategy());
+    TrainingDefinition trainingDefinition =
         trainingDefinitionRepository.save(unreleasedTrainingDefinition);
-        infoLevel1.setTrainingDefinition(unreleasedTrainingDefinition);
-        infoLevelRepository.save(infoLevel1);
-        MockHttpServletResponse result = mvc.perform(get("/training-definitions/levels/{id}", infoLevel1.getId()))
-                .andExpect(status().isOk())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andReturn().getResponse();
-        InfoLevelDTO infoLevelDTO = levelMapper.mapToInfoLevelDTO(infoLevel1);
-        infoLevelDTO.setLevelType(LevelType.INFO_LEVEL);
-        assertEquals(infoLevelDTO, convertJsonBytesToObject(convertJsonBytesToObject(result.getContentAsString()), InfoLevelDTO.class));
-    }
+    MockHttpServletResponse response =
+        mvc.perform(
+                post(
+                    "/training-definitions/{definitionId}/levels/{levelType}",
+                    trainingDefinition.getId(),
+                    cz.cyberrange.platform.training.persistence.model.enums.LevelType.ASSESSMENT))
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isCreated())
+            .andReturn()
+            .getResponse();
 
-    @Test
-    public void findAssessmentLevelById() throws Exception {
-        trainingDefinitionRepository.save(unreleasedTrainingDefinition);
-        assessmentLevelWithoutQuestions.setTrainingDefinition(unreleasedTrainingDefinition);
-        assessmentLevelRepository.save(assessmentLevelWithoutQuestions);
-        MockHttpServletResponse result = mvc.perform(get("/training-definitions/levels/{id}", assessmentLevelWithoutQuestions.getId()))
-                .andExpect(status().isOk())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andReturn().getResponse();
-        AssessmentLevelDTO assessmentLevelDTO = levelMapper.mapToAssessmentLevelDTO(assessmentLevelWithoutQuestions);
-        assessmentLevelDTO.setLevelType(LevelType.ASSESSMENT_LEVEL);
-        assertEquals(assessmentLevelDTO, convertJsonBytesToObject(convertJsonBytesToObject(result.getContentAsString()), AssessmentLevelDTO.class));
-    }
+    BasicLevelInfoDTO levelInfoDTO =
+        convertJsonBytesToObject(
+            convertJsonBytesToObject(response.getContentAsString()), BasicLevelInfoDTO.class);
+    Optional<AssessmentLevel> optionalAssessmentLevel =
+        assessmentLevelRepository.findById(levelInfoDTO.getId());
+    assertTrue(optionalAssessmentLevel.isPresent());
+    AssessmentLevel assessmentLevel = optionalAssessmentLevel.get();
+    assertEquals(0, assessmentLevel.getMaxScore());
+    assertEquals("Title of assessment level", assessmentLevel.getTitle());
+    assertEquals(
+        AssessmentType.QUESTIONNAIRE.toString(), assessmentLevel.getAssessmentType().toString());
+    assertEquals("Instructions should be here", assessmentLevel.getInstructions());
+  }
 
-    @Test
-    public void findTrainingLevelById_NotFound() throws Exception {
-        MockHttpServletResponse response = mvc.perform(get("/training-definitions/levels/{id}", 100L))
-                .andExpect(status().isNotFound())
-                .andReturn().getResponse();
-        ApiEntityError error = convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
-        assertEquals(HttpStatus.NOT_FOUND, error.getStatus());
-        assertEntityDetailError(error.getEntityErrorDetail(), AbstractLevel.class, "id", "100",
-                "Level not found.");
-    }
+  @Test
+  public void createLevel_ReleasedDefinition() throws Exception {
+    trainingDefinitionRepository.save(releasedTrainingDefinition);
+    MockHttpServletResponse response =
+        mvc.perform(
+                post(
+                    "/training-definitions/{definitionId}/levels/{levelType}",
+                    releasedTrainingDefinition.getId(),
+                    cz.cyberrange.platform.training.persistence.model.enums.LevelType.ASSESSMENT))
+            .andExpect(status().isConflict())
+            .andReturn()
+            .getResponse();
+    ApiEntityError error =
+        convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
+    assertEquals(HttpStatus.CONFLICT, error.getStatus());
+    assertEntityDetailError(
+        error.getEntityErrorDetail(),
+        TrainingDefinition.class,
+        "id",
+        releasedTrainingDefinition.getId().toString(),
+        "Cannot edit released or archived training definition.");
+  }
 
-    @Test
-    public void createTrainingLevel() throws Exception {
-        TrainingDefinition trainingDefinition = trainingDefinitionRepository.save(unreleasedTrainingDefinition);
-        MockHttpServletResponse response = mvc.perform(post("/training-definitions/{definitionId}/levels/{levelType}", trainingDefinition.getId(), cz.cyberrange.platform.training.persistence.model.enums.LevelType.TRAINING))
-                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isCreated())
-                .andReturn().getResponse();
+  @Test
+  public void createLevel_ArchivedDefinition() throws Exception {
+    trainingDefinitionRepository.save(archivedTrainingDefinition);
+    MockHttpServletResponse response =
+        mvc.perform(
+                post(
+                    "/training-definitions/{definitionId}/levels/{levelType}",
+                    archivedTrainingDefinition.getId(),
+                    cz.cyberrange.platform.training.persistence.model.enums.LevelType.ASSESSMENT))
+            .andExpect(status().isConflict())
+            .andReturn()
+            .getResponse();
+    ApiEntityError error =
+        convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
+    assertEquals(HttpStatus.CONFLICT, error.getStatus());
+    assertEntityDetailError(
+        error.getEntityErrorDetail(),
+        TrainingDefinition.class,
+        "id",
+        archivedTrainingDefinition.getId().toString(),
+        "Cannot edit released or archived training definition.");
+  }
 
-        BasicLevelInfoDTO levelInfoDTO = convertJsonBytesToObject(convertJsonBytesToObject(response.getContentAsString()), BasicLevelInfoDTO.class);
-        Optional<TrainingLevel> optionalTrainingLevel = trainingLevelRepository.findById(levelInfoDTO.getId());
-        assertTrue(optionalTrainingLevel.isPresent());
-        TrainingLevel trainingLevel = optionalTrainingLevel.get();
-        assertEquals(100, trainingLevel.getMaxScore() );
-        assertEquals("Title of training level", trainingLevel.getTitle());
-        assertEquals(100, trainingLevel.getIncorrectAnswerLimit());
-        assertEquals("Secret answer", trainingLevel.getAnswer());
-        assertTrue(trainingLevel.isSolutionPenalized());
-        assertEquals("Solution of the training should be here", trainingLevel.getSolution());
-        assertEquals("The test entry should be here", trainingLevel.getContent());
-    }
+  @Test
+  public void createLevel_DefinitionNotFound() throws Exception {
+    MockHttpServletResponse response =
+        mvc.perform(
+                post(
+                    "/training-definitions/{definitionId}/levels/{levelType}",
+                    100L,
+                    cz.cyberrange.platform.training.persistence.model.enums.LevelType.ASSESSMENT))
+            .andExpect(status().isNotFound())
+            .andReturn()
+            .getResponse();
+    ApiEntityError error =
+        convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
+    assertEquals(HttpStatus.NOT_FOUND, error.getStatus());
+    assertEntityDetailError(
+        error.getEntityErrorDetail(),
+        TrainingDefinition.class,
+        "id",
+        "100",
+        "Entity TrainingDefinition (id: 100) not found.");
+  }
 
-    @Test
-    public void createInfoLevel() throws Exception {
-        TrainingDefinition trainingDefinition = trainingDefinitionRepository.save(unreleasedTrainingDefinition);
-        MockHttpServletResponse response = mvc.perform(post("/training-definitions/{definitionId}/levels/{levelType}", trainingDefinition.getId(), cz.cyberrange.platform.training.persistence.model.enums.LevelType.INFO))
-                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isCreated())
-                .andReturn().getResponse();
+  @Test
+  public void editAuthors_Add() throws Exception {
+    trainingDefinitionRepository.save(releasedTrainingDefinition);
+    assertTrue(
+        releasedTrainingDefinition.getAuthors().size() == 1
+            && releasedTrainingDefinition.getAuthors().contains(author1));
+    ArgumentMatcher<ClientRequest> userInfoMatcher =
+        clientRequest -> clientRequest.url().getPath().equals("/users/info");
+    doReturn(buildMockResponse(organizerDTO1))
+        .when(exchangeFunction)
+        .exchange(argThat(userInfoMatcher));
+    ArgumentMatcher<ClientRequest> usersIdsMatcher =
+        clientRequest -> clientRequest.url().getPath().equals("/users/ids");
+    doReturn(
+            buildMockResponse(
+                new PageResultResource<UserRefDTO>(
+                    List.of(organizerDTO1, authorDTO1, authorDTO2),
+                    new PageResultResource.Pagination(0, 3, 3, 3, 1))))
+        .when(exchangeFunction)
+        .exchange(argThat(usersIdsMatcher));
 
-        BasicLevelInfoDTO levelInfoDTO = convertJsonBytesToObject(convertJsonBytesToObject(response.getContentAsString()), BasicLevelInfoDTO.class);
-        Optional<InfoLevel> optionalInfoLevel = infoLevelRepository.findById(levelInfoDTO.getId());
-        assertTrue(optionalInfoLevel.isPresent());
-        InfoLevel infoLevel = optionalInfoLevel.get();
-        assertEquals(0, infoLevel.getMaxScore());
-        assertEquals("Title of info level", infoLevel.getTitle());
-        assertEquals("Content of info level should be here.", infoLevel.getContent());
-    }
-
-    @Test
-    public void createAssessmentLevel() throws Exception {
-        mapper.setPropertyNamingStrategy(new PropertyNamingStrategies.SnakeCaseStrategy());
-        TrainingDefinition trainingDefinition = trainingDefinitionRepository.save(unreleasedTrainingDefinition);
-        MockHttpServletResponse response = mvc.perform(post("/training-definitions/{definitionId}/levels/{levelType}", trainingDefinition.getId(), cz.cyberrange.platform.training.persistence.model.enums.LevelType.ASSESSMENT))
-                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isCreated())
-                .andReturn().getResponse();
-
-        BasicLevelInfoDTO levelInfoDTO = convertJsonBytesToObject(convertJsonBytesToObject(response.getContentAsString()), BasicLevelInfoDTO.class);
-        Optional<AssessmentLevel> optionalAssessmentLevel = assessmentLevelRepository.findById(levelInfoDTO.getId());
-        assertTrue(optionalAssessmentLevel.isPresent());
-        AssessmentLevel assessmentLevel = optionalAssessmentLevel.get();
-        assertEquals(0, assessmentLevel.getMaxScore());
-        assertEquals("Title of assessment level", assessmentLevel.getTitle());
-        assertEquals(AssessmentType.QUESTIONNAIRE.toString(), assessmentLevel.getAssessmentType().toString());
-        assertEquals("Instructions should be here", assessmentLevel.getInstructions());
-    }
-
-    @Test
-    public void createLevel_ReleasedDefinition() throws Exception {
-        trainingDefinitionRepository.save(releasedTrainingDefinition);
-        MockHttpServletResponse response = mvc.perform(post("/training-definitions/{definitionId}/levels/{levelType}", releasedTrainingDefinition.getId(), cz.cyberrange.platform.training.persistence.model.enums.LevelType.ASSESSMENT))
-                .andExpect(status().isConflict())
-                .andReturn().getResponse();
-        ApiEntityError error = convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
-        assertEquals(HttpStatus.CONFLICT, error.getStatus());
-        assertEntityDetailError(error.getEntityErrorDetail(), TrainingDefinition.class, "id", releasedTrainingDefinition.getId().toString(),
-                "Cannot edit released or archived training definition.");
-    }
-
-    @Test
-    public void createLevel_ArchivedDefinition() throws Exception {
-        trainingDefinitionRepository.save(archivedTrainingDefinition);
-        MockHttpServletResponse response = mvc.perform(post("/training-definitions/{definitionId}/levels/{levelType}", archivedTrainingDefinition.getId(), cz.cyberrange.platform.training.persistence.model.enums.LevelType.ASSESSMENT))
-                .andExpect(status().isConflict())
-                .andReturn().getResponse();
-        ApiEntityError error = convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
-        assertEquals(HttpStatus.CONFLICT, error.getStatus());
-        assertEntityDetailError(error.getEntityErrorDetail(), TrainingDefinition.class, "id", archivedTrainingDefinition.getId().toString(),
-                "Cannot edit released or archived training definition.");
-    }
-
-    @Test
-    public void createLevel_DefinitionNotFound() throws Exception {
-        MockHttpServletResponse response = mvc.perform(post("/training-definitions/{definitionId}/levels/{levelType}", 100L, cz.cyberrange.platform.training.persistence.model.enums.LevelType.ASSESSMENT))
-                .andExpect(status().isNotFound())
-                .andReturn().getResponse();
-        ApiEntityError error = convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
-        assertEquals(HttpStatus.NOT_FOUND, error.getStatus());
-        assertEntityDetailError(error.getEntityErrorDetail(), TrainingDefinition.class, "id", "100",
-                "Entity TrainingDefinition (id: 100) not found.");
-    }
-
-    @Test
-    public void editAuthors_Add() throws Exception {
-        trainingDefinitionRepository.save(releasedTrainingDefinition);
-        assertTrue(releasedTrainingDefinition.getAuthors().size() == 1 && releasedTrainingDefinition.getAuthors().contains(author1));
-        ArgumentMatcher<ClientRequest> userInfoMatcher = clientRequest -> clientRequest.url().getPath().equals("/users/info");
-        doReturn(buildMockResponse(organizerDTO1)).when(exchangeFunction).exchange(argThat(userInfoMatcher));
-        ArgumentMatcher<ClientRequest> usersIdsMatcher = clientRequest -> clientRequest.url().getPath().equals("/users/ids");
-        doReturn(buildMockResponse(new PageResultResource<UserRefDTO>(List.of(organizerDTO1, authorDTO1, authorDTO2), new PageResultResource.Pagination(0,3,3,3,1))))
-                .when(exchangeFunction).exchange(argThat(usersIdsMatcher));
-
-        mvc.perform(put("/training-definitions/{definitionId}/authors", releasedTrainingDefinition.getId())
-                .queryParam("authorsAddition",  StringUtils.collectionToDelimitedString(List.of(author1.getUserRefId(), author2.getUserRefId(), organizer1.getUserRefId()), ","))
+    mvc.perform(
+            put("/training-definitions/{definitionId}/authors", releasedTrainingDefinition.getId())
+                .queryParam(
+                    "authorsAddition",
+                    StringUtils.collectionToDelimitedString(
+                        List.of(
+                            author1.getUserRefId(),
+                            author2.getUserRefId(),
+                            organizer1.getUserRefId()),
+                        ","))
                 .queryParam("authorsRemoval", ""))
-                .andExpect(status().isNoContent());
-        assertEquals(3, releasedTrainingDefinition.getAuthors().size());
-        assertEquals(Set.of(author1, author2, organizer1), releasedTrainingDefinition.getAuthors());
+        .andExpect(status().isNoContent());
+    assertEquals(3, releasedTrainingDefinition.getAuthors().size());
+    assertEquals(Set.of(author1, author2, organizer1), releasedTrainingDefinition.getAuthors());
+  }
+
+  @Test
+  public void editAuthors_Remove() throws Exception {
+    trainingDefinitionRepository.save(releasedTrainingDefinition);
+    releasedTrainingDefinition.setAuthors(
+        new HashSet<>(Set.of(author1, author2, organizer1, organizer2)));
+    ArgumentMatcher<ClientRequest> userInfoMatcher =
+        clientRequest -> clientRequest.url().getPath().equals("/users/info");
+    doReturn(buildMockResponse(authorDTO1))
+        .when(exchangeFunction)
+        .exchange(argThat(userInfoMatcher));
+
+    mvc.perform(
+            put("/training-definitions/{definitionId}/authors", releasedTrainingDefinition.getId())
+                .queryParam("authorsAddition", "")
+                .queryParam(
+                    "authorsRemoval",
+                    StringUtils.collectionToDelimitedString(
+                        List.of(organizer2.getUserRefId(), organizer1.getUserRefId()), ",")))
+        .andExpect(status().isNoContent());
+    assertEquals(2, releasedTrainingDefinition.getAuthors().size());
+    assertEquals(Set.of(author1, author2), releasedTrainingDefinition.getAuthors());
+  }
+
+  @Test
+  public void editAuthors_RemoveLoggedInAuthor() throws Exception {
+    trainingDefinitionRepository.save(releasedTrainingDefinition);
+    releasedTrainingDefinition.setAuthors(new HashSet<>(Set.of(author1, author2)));
+    ArgumentMatcher<ClientRequest> userInfoMatcher =
+        clientRequest -> clientRequest.url().getPath().equals("/users/info");
+    doReturn(buildMockResponse(authorDTO1))
+        .when(exchangeFunction)
+        .exchange(argThat(userInfoMatcher));
+
+    mvc.perform(
+            put("/training-definitions/{definitionId}/authors", releasedTrainingDefinition.getId())
+                .queryParam("authorsAddition", "")
+                .queryParam(
+                    "authorsRemoval",
+                    StringUtils.collectionToDelimitedString(List.of(author1.getUserRefId()), ",")))
+        .andExpect(status().isNoContent());
+    assertEquals(2, releasedTrainingDefinition.getAuthors().size());
+    assertEquals(Set.of(author1, author2), releasedTrainingDefinition.getAuthors());
+  }
+
+  @Test
+  public void switchStateOfDefinition_DefinitionNotFound() throws Exception {
+    assertEquals(TDState.RELEASED.name(), releasedTrainingDefinition.getState().name());
+    MockHttpServletResponse response =
+        mvc.perform(
+                put(
+                    "/training-definitions/{definitionId}/states/{state}",
+                    1000,
+                    cz.cyberrange.platform.training.persistence.model.enums.TDState.UNRELEASED))
+            .andExpect(status().isNotFound())
+            .andReturn()
+            .getResponse();
+    assertEquals(TDState.RELEASED.name(), releasedTrainingDefinition.getState().name());
+    ApiEntityError error =
+        convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
+    assertEquals(HttpStatus.NOT_FOUND, error.getStatus());
+    assertEntityDetailError(
+        error.getEntityErrorDetail(),
+        TrainingDefinition.class,
+        "id",
+        "1000",
+        "Entity TrainingDefinition (id: 1000) not found.");
+  }
+
+  @Test
+  public void switchStateOfDefinition_UnreleasedToReleased() throws Exception {
+    trainingDefinitionRepository.save(unreleasedTrainingDefinition);
+    assertEquals(TDState.UNRELEASED.name(), unreleasedTrainingDefinition.getState().name());
+    mvc.perform(
+            put(
+                "/training-definitions/{definitionId}/states/{state}",
+                unreleasedTrainingDefinition.getId(),
+                cz.cyberrange.platform.training.persistence.model.enums.TDState.RELEASED))
+        .andExpect(status().isNoContent());
+    assertEquals(TDState.RELEASED.name(), unreleasedTrainingDefinition.getState().name());
+  }
+
+  @Test
+  public void switchStateOfDefinition_UnreleasedToUnreleased() throws Exception {
+    trainingDefinitionRepository.save(unreleasedTrainingDefinition);
+
+    assertEquals(TDState.UNRELEASED.name(), unreleasedTrainingDefinition.getState().name());
+    mvc.perform(
+            put(
+                "/training-definitions/{definitionId}/states/{state}",
+                unreleasedTrainingDefinition.getId(),
+                cz.cyberrange.platform.training.persistence.model.enums.TDState.UNRELEASED))
+        .andExpect(status().isNoContent());
+    assertEquals(TDState.UNRELEASED.name(), unreleasedTrainingDefinition.getState().name());
+  }
+
+  @Test
+  public void switchStateOfDefinition_ReleasedToArchived() throws Exception {
+    trainingDefinitionRepository.save(releasedTrainingDefinition);
+    assertEquals(TDState.RELEASED.name(), releasedTrainingDefinition.getState().name());
+    mvc.perform(
+            put(
+                "/training-definitions/{definitionId}/states/{state}",
+                releasedTrainingDefinition.getId(),
+                cz.cyberrange.platform.training.persistence.model.enums.TDState.ARCHIVED))
+        .andExpect(status().isNoContent());
+    assertEquals(TDState.ARCHIVED.name(), releasedTrainingDefinition.getState().name());
+  }
+
+  @Test
+  public void switchStateOfDefinition_ReleasedToUnreleased_Allowed() throws Exception {
+    trainingDefinitionRepository.save(releasedTrainingDefinition);
+    assertEquals(TDState.RELEASED.name(), releasedTrainingDefinition.getState().name());
+    mvc.perform(
+            put(
+                "/training-definitions/{definitionId}/states/{state}",
+                releasedTrainingDefinition.getId(),
+                cz.cyberrange.platform.training.persistence.model.enums.TDState.UNRELEASED))
+        .andExpect(status().isNoContent());
+    assertEquals(TDState.UNRELEASED.name(), releasedTrainingDefinition.getState().name());
+  }
+
+  @Test
+  public void switchStateOfDefinition_ReleasedToUnreleased_NotAllowed() throws Exception {
+    trainingDefinitionRepository.save(releasedTrainingDefinition);
+    trainingInstance.setTrainingDefinition(releasedTrainingDefinition);
+    trainingInstanceRepository.save(trainingInstance);
+
+    assertEquals(TDState.RELEASED.name(), releasedTrainingDefinition.getState().name());
+    MockHttpServletResponse response =
+        mvc.perform(
+                put(
+                    "/training-definitions/{definitionId}/states/{state}",
+                    releasedTrainingDefinition.getId(),
+                    cz.cyberrange.platform.training.persistence.model.enums.TDState.UNRELEASED))
+            .andExpect(status().isConflict())
+            .andReturn()
+            .getResponse();
+    assertEquals(TDState.RELEASED.name(), releasedTrainingDefinition.getState().name());
+    ApiEntityError error =
+        convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
+    assertEquals(HttpStatus.CONFLICT, error.getStatus());
+    assertEntityDetailError(
+        error.getEntityErrorDetail(),
+        TrainingDefinition.class,
+        "id",
+        releasedTrainingDefinition.getId().toString(),
+        "Cannot update training definition with already created training instance(s). Remove training "
+            + "instance(s) before changing the state from released to unreleased training definition.");
+  }
+
+  @Test
+  public void switchStateOfDefinition_ArchivedToUnreleased() throws Exception {
+    trainingDefinitionRepository.save(archivedTrainingDefinition);
+
+    assertEquals(TDState.ARCHIVED.name(), archivedTrainingDefinition.getState().name());
+    MockHttpServletResponse response =
+        mvc.perform(
+                put(
+                    "/training-definitions/{definitionId}/states/{state}",
+                    archivedTrainingDefinition.getId(),
+                    cz.cyberrange.platform.training.persistence.model.enums.TDState.UNRELEASED))
+            .andExpect(status().isConflict())
+            .andReturn()
+            .getResponse();
+    assertEquals(TDState.ARCHIVED.name(), archivedTrainingDefinition.getState().name());
+    ApiEntityError error =
+        convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
+    assertEquals(HttpStatus.CONFLICT, error.getStatus());
+    assertEntityDetailError(
+        error.getEntityErrorDetail(),
+        TrainingDefinition.class,
+        "id",
+        archivedTrainingDefinition.getId().toString(),
+        "Cannot switch from " + TDState.ARCHIVED.name() + " to " + TDState.UNRELEASED.name());
+  }
+
+  private void mockSpringSecurityContextForGet(List<String> roles) {
+    List<GrantedAuthority> authorities = new ArrayList<>();
+    for (String role : roles) {
+      authorities.add(new SimpleGrantedAuthority(role));
     }
+    Jwt jwt =
+        new Jwt(
+            "bearer-token-value",
+            null,
+            null,
+            Map.of("alg", "HS256"),
+            Map.of(
+                OIDCItems.ISS.getName(), "oidc-issuer", OIDCItems.SUB.getName(), "mail@test.cz"));
+    JwtAuthenticationToken authenticationToken = new JwtAuthenticationToken(jwt, authorities);
 
-    @Test
-    public void editAuthors_Remove() throws Exception {
-        trainingDefinitionRepository.save(releasedTrainingDefinition);
-        releasedTrainingDefinition.setAuthors(new HashSet<>(Set.of(author1, author2, organizer1, organizer2)));
-        ArgumentMatcher<ClientRequest> userInfoMatcher = clientRequest -> clientRequest.url().getPath().equals("/users/info");
-        doReturn(buildMockResponse(authorDTO1)).when(exchangeFunction).exchange(argThat(userInfoMatcher));
+    SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+  }
 
-        mvc.perform(put("/training-definitions/{definitionId}/authors", releasedTrainingDefinition.getId())
-                .queryParam("authorsAddition",  "")
-                .queryParam("authorsRemoval", StringUtils.collectionToDelimitedString(List.of(organizer2.getUserRefId(), organizer1.getUserRefId()), ",")))
-                .andExpect(status().isNoContent());
-        assertEquals(2, releasedTrainingDefinition.getAuthors().size());
-        assertEquals(Set.of(author1, author2), releasedTrainingDefinition.getAuthors());
+  private void assertEntityDetailError(
+      EntityErrorDetail entityErrorDetail,
+      Class<?> entity,
+      String identifier,
+      Object value,
+      String reason) {
+    assertEquals(entity.getSimpleName(), entityErrorDetail.getEntity());
+    assertEquals(identifier, entityErrorDetail.getIdentifier());
+    if (entityErrorDetail.getIdentifierValue() == null) {
+      assertEquals(value, entityErrorDetail.getIdentifierValue());
+    } else {
+      assertEquals(value, entityErrorDetail.getIdentifierValue().toString());
     }
+    assertEquals(reason, entityErrorDetail.getReason());
+  }
 
-    @Test
-    public void editAuthors_RemoveLoggedInAuthor() throws Exception {
-        trainingDefinitionRepository.save(releasedTrainingDefinition);
-        releasedTrainingDefinition.setAuthors(new HashSet<>(Set.of(author1, author2)));
-        ArgumentMatcher<ClientRequest> userInfoMatcher = clientRequest -> clientRequest.url().getPath().equals("/users/info");
-        doReturn(buildMockResponse(authorDTO1)).when(exchangeFunction).exchange(argThat(userInfoMatcher));
+  private Mono<ClientResponse> buildMockResponse(Object body) throws IOException {
+    ClientResponse clientResponse =
+        ClientResponse.create(HttpStatus.OK)
+            .body(convertObjectToJsonBytes(body))
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .build();
+    return Mono.just(clientResponse);
+  }
 
-        mvc.perform(put("/training-definitions/{definitionId}/authors", releasedTrainingDefinition.getId())
-                .queryParam("authorsAddition",  "")
-                .queryParam("authorsRemoval", StringUtils.collectionToDelimitedString(List.of(author1.getUserRefId()), ",")))
-                .andExpect(status().isNoContent());
-        assertEquals(2, releasedTrainingDefinition.getAuthors().size());
-        assertEquals(Set.of(author1, author2), releasedTrainingDefinition.getAuthors());
-    }
-
-    @Test
-    public void switchStateOfDefinition_DefinitionNotFound() throws Exception {
-        assertEquals(TDState.RELEASED.name(), releasedTrainingDefinition.getState().name());
-        MockHttpServletResponse response = mvc.perform(put("/training-definitions/{definitionId}/states/{state}", 1000, cz.cyberrange.platform.training.persistence.model.enums.TDState.UNRELEASED))
-                .andExpect(status().isNotFound())
-                .andReturn().getResponse();
-        assertEquals(TDState.RELEASED.name(), releasedTrainingDefinition.getState().name());
-        ApiEntityError error = convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
-        assertEquals(HttpStatus.NOT_FOUND, error.getStatus());
-        assertEntityDetailError(error.getEntityErrorDetail(), TrainingDefinition.class, "id", "1000",
-                "Entity TrainingDefinition (id: 1000) not found.");
-    }
-
-    @Test
-    public void switchStateOfDefinition_UnreleasedToReleased() throws Exception {
-        trainingDefinitionRepository.save(unreleasedTrainingDefinition);
-        assertEquals(TDState.UNRELEASED.name(), unreleasedTrainingDefinition.getState().name());
-        mvc.perform(put("/training-definitions/{definitionId}/states/{state}", unreleasedTrainingDefinition.getId(), cz.cyberrange.platform.training.persistence.model.enums.TDState.RELEASED))
-                .andExpect(status().isNoContent());
-        assertEquals(TDState.RELEASED.name(), unreleasedTrainingDefinition.getState().name());
-    }
-
-    @Test
-    public void switchStateOfDefinition_UnreleasedToUnreleased() throws Exception {
-        trainingDefinitionRepository.save(unreleasedTrainingDefinition);
-
-        assertEquals(TDState.UNRELEASED.name(), unreleasedTrainingDefinition.getState().name());
-        mvc.perform(put("/training-definitions/{definitionId}/states/{state}", unreleasedTrainingDefinition.getId(), cz.cyberrange.platform.training.persistence.model.enums.TDState.UNRELEASED))
-                .andExpect(status().isNoContent());
-        assertEquals(TDState.UNRELEASED.name(), unreleasedTrainingDefinition.getState().name());
-    }
-
-    @Test
-    public void switchStateOfDefinition_ReleasedToArchived() throws Exception {
-        trainingDefinitionRepository.save(releasedTrainingDefinition);
-        assertEquals(TDState.RELEASED.name(), releasedTrainingDefinition.getState().name());
-        mvc.perform(put("/training-definitions/{definitionId}/states/{state}", releasedTrainingDefinition.getId(), cz.cyberrange.platform.training.persistence.model.enums.TDState.ARCHIVED))
-                .andExpect(status().isNoContent());
-        assertEquals(TDState.ARCHIVED.name(), releasedTrainingDefinition.getState().name());
-    }
-
-    @Test
-    public void switchStateOfDefinition_ReleasedToUnreleased_Allowed() throws Exception {
-        trainingDefinitionRepository.save(releasedTrainingDefinition);
-        assertEquals(TDState.RELEASED.name(), releasedTrainingDefinition.getState().name());
-        mvc.perform(put("/training-definitions/{definitionId}/states/{state}", releasedTrainingDefinition.getId(), cz.cyberrange.platform.training.persistence.model.enums.TDState.UNRELEASED))
-                .andExpect(status().isNoContent());
-        assertEquals(TDState.UNRELEASED.name(), releasedTrainingDefinition.getState().name());
-    }
-
-    @Test
-    public void switchStateOfDefinition_ReleasedToUnreleased_NotAllowed() throws Exception {
-        trainingDefinitionRepository.save(releasedTrainingDefinition);
-        trainingInstance.setTrainingDefinition(releasedTrainingDefinition);
-        trainingInstanceRepository.save(trainingInstance);
-
-        assertEquals(TDState.RELEASED.name(), releasedTrainingDefinition.getState().name());
-        MockHttpServletResponse response = mvc.perform(put("/training-definitions/{definitionId}/states/{state}", releasedTrainingDefinition.getId(), cz.cyberrange.platform.training.persistence.model.enums.TDState.UNRELEASED))
-                .andExpect(status().isConflict())
-                .andReturn().getResponse();
-        assertEquals(TDState.RELEASED.name(), releasedTrainingDefinition.getState().name());
-        ApiEntityError error = convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
-        assertEquals(HttpStatus.CONFLICT, error.getStatus());
-        assertEntityDetailError(error.getEntityErrorDetail(), TrainingDefinition.class, "id", releasedTrainingDefinition.getId().toString(),
-                "Cannot update training definition with already created training instance(s). Remove training " +
-                        "instance(s) before changing the state from released to unreleased training definition.");
-    }
-
-    @Test
-    public void switchStateOfDefinition_ArchivedToUnreleased() throws Exception {
-        trainingDefinitionRepository.save(archivedTrainingDefinition);
-
-        assertEquals(TDState.ARCHIVED.name(), archivedTrainingDefinition.getState().name());
-        MockHttpServletResponse response = mvc.perform(put("/training-definitions/{definitionId}/states/{state}",
-                archivedTrainingDefinition.getId(), cz.cyberrange.platform.training.persistence.model.enums.TDState.UNRELEASED))
-                .andExpect(status().isConflict())
-                .andReturn().getResponse();
-        assertEquals(TDState.ARCHIVED.name(), archivedTrainingDefinition.getState().name());
-        ApiEntityError error = convertJsonBytesToObject(response.getContentAsString(), ApiEntityError.class);
-        assertEquals(HttpStatus.CONFLICT, error.getStatus());
-        assertEntityDetailError(error.getEntityErrorDetail(), TrainingDefinition.class, "id", archivedTrainingDefinition.getId().toString(),
-                "Cannot switch from " + TDState.ARCHIVED.name() + " to " + TDState.UNRELEASED.name());
-    }
-
-
-
-    private void mockSpringSecurityContextForGet(List<String> roles) {
-        List<GrantedAuthority> authorities = new ArrayList<>();
-        for (String role : roles) {
-            authorities.add(new SimpleGrantedAuthority(role));
-        }
-        Jwt jwt = new Jwt("bearer-token-value", null, null, Map.of("alg", "HS256"),
-                Map.of(OIDCItems.ISS.getName(), "oidc-issuer", OIDCItems.SUB.getName(), "mail@test.cz"));
-        JwtAuthenticationToken authenticationToken = new JwtAuthenticationToken(jwt, authorities);
-
-        SecurityContextHolder.getContext().setAuthentication(authenticationToken);
-    }
-
-    private void assertEntityDetailError(EntityErrorDetail entityErrorDetail, Class<?> entity, String identifier, Object value, String reason) {
-        assertEquals(entity.getSimpleName(), entityErrorDetail.getEntity());
-        assertEquals(identifier, entityErrorDetail.getIdentifier());
-        if (entityErrorDetail.getIdentifierValue() == null) {
-            assertEquals(value, entityErrorDetail.getIdentifierValue());
-        } else {
-            assertEquals(value, entityErrorDetail.getIdentifierValue().toString());
-        }
-        assertEquals(reason, entityErrorDetail.getReason());
-    }
-
-    private Mono<ClientResponse> buildMockResponse(Object body) throws IOException{
-        ClientResponse clientResponse = ClientResponse.create(HttpStatus.OK)
-                .body(convertObjectToJsonBytes(body))
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                .build();
-        return Mono.just(clientResponse);
-    }
-
-    private void assertQuestionAfterUpdate(AssessmentLevel updatedAssessmentLevel) {
-        assessmentLevelUpdateDTO.getQuestions().forEach(questionDTO -> {
-            if (questionDTO.getQuestionType() == QuestionType.FFQ) {
-                Optional<Question> freeFormQuestion = updatedAssessmentLevel.getQuestions().stream()
-                        .filter(question -> question.getQuestionType() == cz.cyberrange.platform.training.persistence.model.enums.QuestionType.FFQ)
+  private void assertQuestionAfterUpdate(AssessmentLevel updatedAssessmentLevel) {
+    assessmentLevelUpdateDTO
+        .getQuestions()
+        .forEach(
+            questionDTO -> {
+              if (questionDTO.getQuestionType() == QuestionType.FFQ) {
+                Optional<Question> freeFormQuestion =
+                    updatedAssessmentLevel.getQuestions().stream()
+                        .filter(
+                            question ->
+                                question.getQuestionType()
+                                    == cz.cyberrange.platform.training.persistence.model.enums
+                                        .QuestionType.FFQ)
                         .findFirst();
                 assertTrue(freeFormQuestion.isPresent());
-                assertEquals(questionDTO.getChoices().size(), freeFormQuestion.get().getChoices().size());
-            } else if (questionDTO.getQuestionType() == QuestionType.MCQ) {
-                Optional<Question> multipleChoiceQuestion = updatedAssessmentLevel.getQuestions().stream()
-                        .filter(question -> question.getQuestionType() == cz.cyberrange.platform.training.persistence.model.enums.QuestionType.MCQ)
+                assertEquals(
+                    questionDTO.getChoices().size(), freeFormQuestion.get().getChoices().size());
+              } else if (questionDTO.getQuestionType() == QuestionType.MCQ) {
+                Optional<Question> multipleChoiceQuestion =
+                    updatedAssessmentLevel.getQuestions().stream()
+                        .filter(
+                            question ->
+                                question.getQuestionType()
+                                    == cz.cyberrange.platform.training.persistence.model.enums
+                                        .QuestionType.MCQ)
                         .findFirst();
                 assertTrue(multipleChoiceQuestion.isPresent());
-                assertEquals(questionDTO.getChoices().size(), multipleChoiceQuestion.get().getChoices().size());
-            } else {
-                Optional<Question> extendedMatchingItemsQuestion = updatedAssessmentLevel.getQuestions().stream()
-                        .filter(question -> question.getQuestionType() == cz.cyberrange.platform.training.persistence.model.enums.QuestionType.EMI)
+                assertEquals(
+                    questionDTO.getChoices().size(),
+                    multipleChoiceQuestion.get().getChoices().size());
+              } else {
+                Optional<Question> extendedMatchingItemsQuestion =
+                    updatedAssessmentLevel.getQuestions().stream()
+                        .filter(
+                            question ->
+                                question.getQuestionType()
+                                    == cz.cyberrange.platform.training.persistence.model.enums
+                                        .QuestionType.EMI)
                         .findFirst();
                 assertTrue(extendedMatchingItemsQuestion.isPresent());
-                assertEquals(questionDTO.getExtendedMatchingStatements().size(), extendedMatchingItemsQuestion.get().getExtendedMatchingStatements().size());
-                assertEquals(questionDTO.getExtendedMatchingOptions().size(), extendedMatchingItemsQuestion.get().getExtendedMatchingOptions().size());
+                assertEquals(
+                    questionDTO.getExtendedMatchingStatements().size(),
+                    extendedMatchingItemsQuestion.get().getExtendedMatchingStatements().size());
+                assertEquals(
+                    questionDTO.getExtendedMatchingOptions().size(),
+                    extendedMatchingItemsQuestion.get().getExtendedMatchingOptions().size());
                 AtomicInteger index = new AtomicInteger();
-                questionDTO.getExtendedMatchingStatements().forEach(emi -> {
-                    Integer optionOrder = extendedMatchingItemsQuestion.get().getExtendedMatchingStatements()
-                            .get(index.getAndIncrement())
-                            .getExtendedMatchingOption()
-                            .getOrder();
-                    assertEquals(optionOrder, emi.getCorrectOptionOrder());
-                });
-            }
-        });
-    }
+                questionDTO
+                    .getExtendedMatchingStatements()
+                    .forEach(
+                        emi -> {
+                          Integer optionOrder =
+                              extendedMatchingItemsQuestion
+                                  .get()
+                                  .getExtendedMatchingStatements()
+                                  .get(index.getAndIncrement())
+                                  .getExtendedMatchingOption()
+                                  .getOrder();
+                          assertEquals(optionOrder, emi.getCorrectOptionOrder());
+                        });
+              }
+            });
+  }
 }
-

--- a/training-service/src/main/java/cz/cyberrange/platform/training/service/facade/detection/CheatingDetectionFacade.java
+++ b/training-service/src/main/java/cz/cyberrange/platform/training/service/facade/detection/CheatingDetectionFacade.java
@@ -5,7 +5,6 @@ import cz.cyberrange.platform.training.api.responses.PageResultResource;
 import cz.cyberrange.platform.training.persistence.model.detection.CheatingDetection;
 import cz.cyberrange.platform.training.service.annotations.transactions.TransactionalWO;
 import cz.cyberrange.platform.training.service.mapping.mapstruct.detection.CheatingDetectionMapper;
-import cz.cyberrange.platform.training.service.services.SecurityService;
 import cz.cyberrange.platform.training.service.services.UserService;
 import cz.cyberrange.platform.training.service.services.detection.CheatingDetectionService;
 import cz.cyberrange.platform.training.service.services.detection.DetectionEventService;
@@ -15,97 +14,95 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-/**
- * The type Cheating Detection facade.
- */
+/** The type Cheating Detection facade. */
 @Service
 @Transactional
 public class CheatingDetectionFacade {
 
-    private final CheatingDetectionService cheatingDetectionService;
-    private final DetectionEventService detectionEventService;
-    public final UserService userService;
-    private final CheatingDetectionMapper cheatingDetectionMapper;
-    private final SecurityService securityService;
+  private final CheatingDetectionService cheatingDetectionService;
+  private final DetectionEventService detectionEventService;
+  public final UserService userService;
+  private final CheatingDetectionMapper cheatingDetectionMapper;
 
-    /**
-     * Instantiates a new Cheating detection facade.
-     *
-     * @param cheatingDetectionService the cheating detection service
-     * @param detectionEventService the detection event service
-     * @param userService              the user service
-     * @param cheatingDetectionMapper  the cheating detection mapper
-     * @param securityService          the security service
-     */
-    @Autowired
-    public CheatingDetectionFacade(CheatingDetectionService cheatingDetectionService,
-                                   DetectionEventService detectionEventService,
-                                   UserService userService,
-                                   CheatingDetectionMapper cheatingDetectionMapper,
-                                   SecurityService securityService) {
-        this.cheatingDetectionService = cheatingDetectionService;
-        this.detectionEventService = detectionEventService;
-        this.userService = userService;
-        this.cheatingDetectionMapper = cheatingDetectionMapper;
-        this.securityService = securityService;
-    }
+  /**
+   * Instantiates a new Cheating detection facade.
+   *
+   * @param cheatingDetectionService the cheating detection service
+   * @param detectionEventService the detection event service
+   * @param userService the user service
+   * @param cheatingDetectionMapper the cheating detection mapper
+   */
+  @Autowired
+  public CheatingDetectionFacade(
+      CheatingDetectionService cheatingDetectionService,
+      DetectionEventService detectionEventService,
+      UserService userService,
+      CheatingDetectionMapper cheatingDetectionMapper) {
+    this.cheatingDetectionService = cheatingDetectionService;
+    this.detectionEventService = detectionEventService;
+    this.userService = userService;
+    this.cheatingDetectionMapper = cheatingDetectionMapper;
+  }
 
+  /**
+   * Create a new cheating detection and execute it.
+   *
+   * @param cheatingDetectionDTO object with constructor information
+   */
+  @PreAuthorize(
+      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)"
+          + "or @securityService.isOrganizerOfGivenTrainingInstance(#cheatingDetectionDTO.getTrainingInstanceId())")
+  @TransactionalWO
+  public void createAndExecute(CheatingDetectionDTO cheatingDetectionDTO) {
+    CheatingDetection cd = this.cheatingDetectionMapper.mapToEntity(cheatingDetectionDTO);
+    this.cheatingDetectionService.createCheatingDetection(cd);
+    this.cheatingDetectionService.executeCheatingDetection(cd);
+  }
 
-    /**
-     * Create a new cheating detection and execute it.
-     *
-     * @param cheatingDetectionDTO object with constructor information
-     */
-    @PreAuthorize("hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)" +
-            "or @securityService.isOrganizerOfGivenTrainingInstance(#cheatingDetectionDTO.getTrainingInstanceId())")
-    @TransactionalWO
-    public void createAndExecute(CheatingDetectionDTO cheatingDetectionDTO) {
-        CheatingDetection cd = this.cheatingDetectionMapper.mapToEntity(cheatingDetectionDTO);
-        this.cheatingDetectionService.createCheatingDetection(cd);
-        this.cheatingDetectionService.executeCheatingDetection(cd);
-    }
+  /**
+   * Rerun cheating detection
+   *
+   * @param cheatingDetectionId id of cheating detection for rerun.
+   * @param trainingInstanceId id of training instance.
+   */
+  @PreAuthorize(
+      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)"
+          + "or @securityService.isOrganizerOfGivenTrainingInstance(#trainingInstanceId)")
+  @TransactionalWO
+  public void rerunCheatingDetection(Long cheatingDetectionId, Long trainingInstanceId) {
+    this.detectionEventService.deleteDetectionEvents(cheatingDetectionId);
+    this.cheatingDetectionService.reExecuteCheatingDetection(cheatingDetectionId);
+  }
 
-    /**
-     * Rerun cheating detection
-     *
-     * @param cheatingDetectionId id of cheating detection for rerun.
-     * @param trainingInstanceId  id of training instance.
-     */
-    @PreAuthorize("hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)" +
-            "or @securityService.isOrganizerOfGivenTrainingInstance(#trainingInstanceId)")
-    @TransactionalWO
-    public void rerunCheatingDetection(Long cheatingDetectionId, Long trainingInstanceId) {
-        this.detectionEventService.deleteDetectionEvents(cheatingDetectionId);
-        this.cheatingDetectionService.reExecuteCheatingDetection(cheatingDetectionId);
-    }
+  /**
+   * Deletes cheating detection and all its associated events.
+   *
+   * @param cheatingDetectionId id of cheating detection.
+   * @param trainingInstanceId id of training instance.
+   */
+  @PreAuthorize(
+      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)"
+          + "or @securityService.isOrganizerOfGivenTrainingInstance(#trainingInstanceId)")
+  @TransactionalWO
+  public void deleteCheatingDetection(Long cheatingDetectionId, Long trainingInstanceId) {
+    this.cheatingDetectionService.deleteCheatingDetection(cheatingDetectionId, trainingInstanceId);
+  }
 
-    /**
-     * Deletes cheating detection and all its associated events.
-     *
-     * @param cheatingDetectionId id of cheating detection.
-     * @param trainingInstanceId  id of training instance.
-     */
-    @PreAuthorize("hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)" +
-            "or @securityService.isOrganizerOfGivenTrainingInstance(#trainingInstanceId)")
-    @TransactionalWO
-    public void deleteCheatingDetection(Long cheatingDetectionId, Long trainingInstanceId) {
-        this.cheatingDetectionService.deleteCheatingDetection(cheatingDetectionId, trainingInstanceId);
-    }
+  /**
+   * Find all cheating detections of a training instance
+   *
+   * @param trainingInstanceId id of Training instance for cheating detection.
+   * @param pageable pageable parameter with information about pagination.
+   */
+  @PreAuthorize(
+      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)"
+          + "or @securityService.isOrganizerOfGivenTrainingInstance(#trainingInstanceId)")
+  @TransactionalWO
+  public PageResultResource<CheatingDetectionDTO> findAllCheatingDetectionsOfTrainingInstance(
+      Long trainingInstanceId, Pageable pageable) {
 
-
-    /**
-     * Find all cheating detections of a training instance
-     *
-     * @param trainingInstanceId id of Training instance for cheating detection.
-     * @param pageable           pageable parameter with information about pagination.
-     */
-    @PreAuthorize("hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)" +
-            "or @securityService.isOrganizerOfGivenTrainingInstance(#trainingInstanceId)")
-    @TransactionalWO
-    public PageResultResource<CheatingDetectionDTO> findAllCheatingDetectionsOfTrainingInstance(Long trainingInstanceId, Pageable pageable) {
-
-        return cheatingDetectionMapper.mapToPageResultResource(
-                this.cheatingDetectionService.findAllCheatingDetectionsOfTrainingInstance(trainingInstanceId, pageable));
-    }
+    return cheatingDetectionMapper.mapToPageResultResource(
+        this.cheatingDetectionService.findAllCheatingDetectionsOfTrainingInstance(
+            trainingInstanceId, pageable));
+  }
 }
-

--- a/training-service/src/main/java/cz/cyberrange/platform/training/service/facade/detection/DetectionEventFacade.java
+++ b/training-service/src/main/java/cz/cyberrange/platform/training/service/facade/detection/DetectionEventFacade.java
@@ -15,7 +15,6 @@ import cz.cyberrange.platform.training.service.annotations.transactions.Transact
 import cz.cyberrange.platform.training.service.mapping.mapstruct.detection.DetectedForbiddenCommandMapper;
 import cz.cyberrange.platform.training.service.mapping.mapstruct.detection.DetectionEventMapper;
 import cz.cyberrange.platform.training.service.mapping.mapstruct.detection.DetectionEventParticipantMapper;
-import cz.cyberrange.platform.training.service.services.SecurityService;
 import cz.cyberrange.platform.training.service.services.UserService;
 import cz.cyberrange.platform.training.service.services.detection.AnswerSimilarityService;
 import cz.cyberrange.platform.training.service.services.detection.DetectionEventService;
@@ -24,204 +23,218 @@ import cz.cyberrange.platform.training.service.services.detection.LocationSimila
 import cz.cyberrange.platform.training.service.services.detection.MinimalSolveTimeService;
 import cz.cyberrange.platform.training.service.services.detection.NoCommandsService;
 import cz.cyberrange.platform.training.service.services.detection.TimeProximityService;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
 @Service
 @Transactional
 public class DetectionEventFacade {
-    private final AnswerSimilarityService answerSimilarityService;
-    private final LocationSimilarityService locationSimilarityService;
-    private final MinimalSolveTimeService minimalSolveTimeService;
-    private final TimeProximityService timeProximityService;
-    private final NoCommandsService noCommandsService;
-    private final ForbiddenCommandsService forbiddenCommandsService;
-    private final DetectionEventService detectionEventService;
-    public final UserService userService;
-    private final DetectionEventMapper detectionEventMapper;
-    private final DetectionEventParticipantMapper detectionEventParticipantMapper;
+  private final AnswerSimilarityService answerSimilarityService;
+  private final LocationSimilarityService locationSimilarityService;
+  private final MinimalSolveTimeService minimalSolveTimeService;
+  private final TimeProximityService timeProximityService;
+  private final NoCommandsService noCommandsService;
+  private final ForbiddenCommandsService forbiddenCommandsService;
+  private final DetectionEventService detectionEventService;
+  public final UserService userService;
+  private final DetectionEventMapper detectionEventMapper;
+  private final DetectionEventParticipantMapper detectionEventParticipantMapper;
 
-    private final DetectedForbiddenCommandMapper detectedForbiddenCommandMapper;
-    private final SecurityService securityService;
+  private final DetectedForbiddenCommandMapper detectedForbiddenCommandMapper;
 
-    /**
-     * Instantiates a new Cheating detection facade.
-     *
-     * @param userService                     the user service
-     * @param detectionEventMapper            the cheating detection mapper
-     * @param detectionEventParticipantMapper the detection event participant mapper
-     * @param forbiddenCommandMapper          the forbidden command mapper
-     * @param answerSimilarityService         the answer similarity service
-     * @param locationSimilarityService       the location similarity service
-     * @param minimalSolveTimeService         the minimal solve time service
-     * @param timeProximityService            the time proximity service
-     * @param noCommandsService               the no commands service
-     * @param forbiddenCommandsService        the forbidden commands service
-     * @param detectionEventService     the detection event service
-     * @param securityService                 the security service
-     */
-    @Autowired
-    public DetectionEventFacade(UserService userService,
-                                DetectionEventMapper detectionEventMapper,
-                                DetectionEventParticipantMapper detectionEventParticipantMapper,
-                                DetectedForbiddenCommandMapper forbiddenCommandMapper,
-                                DetectionEventService detectionEventService,
-                                AnswerSimilarityService answerSimilarityService,
-                                LocationSimilarityService locationSimilarityService,
-                                MinimalSolveTimeService minimalSolveTimeService,
-                                TimeProximityService timeProximityService,
-                                NoCommandsService noCommandsService,
-                                ForbiddenCommandsService forbiddenCommandsService,
-                                SecurityService securityService) {
-        this.userService = userService;
-        this.detectionEventMapper = detectionEventMapper;
-        this.detectionEventParticipantMapper = detectionEventParticipantMapper;
-        this.detectedForbiddenCommandMapper = forbiddenCommandMapper;
-        this.detectionEventService = detectionEventService;
-        this.answerSimilarityService = answerSimilarityService;
-        this.locationSimilarityService = locationSimilarityService;
-        this.minimalSolveTimeService = minimalSolveTimeService;
-        this.timeProximityService = timeProximityService;
-        this.noCommandsService = noCommandsService;
-        this.forbiddenCommandsService = forbiddenCommandsService;
-        this.securityService = securityService;
-    }
+  /**
+   * Instantiates a new Cheating detection facade.
+   *
+   * @param userService the user service
+   * @param detectionEventMapper the cheating detection mapper
+   * @param detectionEventParticipantMapper the detection event participant mapper
+   * @param forbiddenCommandMapper the forbidden command mapper
+   * @param answerSimilarityService the answer similarity service
+   * @param locationSimilarityService the location similarity service
+   * @param minimalSolveTimeService the minimal solve time service
+   * @param timeProximityService the time proximity service
+   * @param noCommandsService the no commands service
+   * @param forbiddenCommandsService the forbidden commands service
+   * @param detectionEventService the detection event service
+   */
+  @Autowired
+  public DetectionEventFacade(
+      UserService userService,
+      DetectionEventMapper detectionEventMapper,
+      DetectionEventParticipantMapper detectionEventParticipantMapper,
+      DetectedForbiddenCommandMapper forbiddenCommandMapper,
+      DetectionEventService detectionEventService,
+      AnswerSimilarityService answerSimilarityService,
+      LocationSimilarityService locationSimilarityService,
+      MinimalSolveTimeService minimalSolveTimeService,
+      TimeProximityService timeProximityService,
+      NoCommandsService noCommandsService,
+      ForbiddenCommandsService forbiddenCommandsService) {
+    this.userService = userService;
+    this.detectionEventMapper = detectionEventMapper;
+    this.detectionEventParticipantMapper = detectionEventParticipantMapper;
+    this.detectedForbiddenCommandMapper = forbiddenCommandMapper;
+    this.detectionEventService = detectionEventService;
+    this.answerSimilarityService = answerSimilarityService;
+    this.locationSimilarityService = locationSimilarityService;
+    this.minimalSolveTimeService = minimalSolveTimeService;
+    this.timeProximityService = timeProximityService;
+    this.noCommandsService = noCommandsService;
+    this.forbiddenCommandsService = forbiddenCommandsService;
+  }
 
-    /**
-     * Finds all detection events of a cheating detection.
-     *
-     * @param cheatingDetectionId the cheating detection ID
-     * @param pageable            the pageable
-     */
-    @PreAuthorize("hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)" +
-            "or @securityService.isOrganizerOfGivenTrainingInstance(#trainingInstanceId)")
-    @TransactionalWO
-    public PageResultResource<AbstractDetectionEventDTO> findAllDetectionEventsOfCheatingDetection(Long cheatingDetectionId,
-                                                                                                   Pageable pageable,
-                                                                                                   Predicate predicate,
-                                                                                                   Long trainingInstanceId) {
-        return detectionEventMapper.mapToPageResultResource(
-                this.detectionEventService.findAllDetectionEventsOfCheatingDetection(cheatingDetectionId, pageable, predicate));
-    }
+  /**
+   * Finds all detection events of a cheating detection.
+   *
+   * @param cheatingDetectionId the cheating detection ID
+   * @param pageable the pageable
+   */
+  @PreAuthorize(
+      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)"
+          + "or @securityService.isOrganizerOfGivenTrainingInstance(#trainingInstanceId)")
+  @TransactionalWO
+  public PageResultResource<AbstractDetectionEventDTO> findAllDetectionEventsOfCheatingDetection(
+      Long cheatingDetectionId, Pageable pageable, Predicate predicate, Long trainingInstanceId) {
+    return detectionEventMapper.mapToPageResultResource(
+        this.detectionEventService.findAllDetectionEventsOfCheatingDetection(
+            cheatingDetectionId, pageable, predicate));
+  }
 
-    /**
-     * Finds all participants of detection event.
-     *
-     * @param eventId  the detection event ID
-     * @param pageable the pageable
-     */
-    @PreAuthorize("hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)")
-    @TransactionalWO
-    public PageResultResource<DetectionEventParticipantDTO> findAllParticipantsOfDetectionEvent(Long eventId,
-                                                                                                Pageable pageable) {
-        return detectionEventParticipantMapper.mapToPageResultResource(
-                this.detectionEventService.findAllParticipantsOfEvent(eventId, pageable));
-    }
+  /**
+   * Finds all participants of detection event.
+   *
+   * @param eventId the detection event ID
+   * @param pageable the pageable
+   */
+  @PreAuthorize(
+      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)")
+  @TransactionalWO
+  public PageResultResource<DetectionEventParticipantDTO> findAllParticipantsOfDetectionEvent(
+      Long eventId, Pageable pageable) {
+    return detectionEventParticipantMapper.mapToPageResultResource(
+        this.detectionEventService.findAllParticipantsOfEvent(eventId, pageable));
+  }
 
-    /**
-     * Finds all forbidden commands of detection event.
-     *
-     * @param eventId  the detection event ID
-     * @param pageable the pageable
-     */
-    @PreAuthorize("hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)")
-    @TransactionalWO
-    public PageResultResource<DetectedForbiddenCommandDTO> findAllForbiddenCommandsOfDetectionEvent(Long eventId,
-                                                                                                    Pageable pageable) {
-        return detectedForbiddenCommandMapper.mapToPageResultResource(
-                this.detectionEventService.findAllForbiddenCommandsOfDetectionEvent(eventId, pageable));
-    }
+  /**
+   * Finds all forbidden commands of detection event.
+   *
+   * @param eventId the detection event ID
+   * @param pageable the pageable
+   */
+  @PreAuthorize(
+      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)")
+  @TransactionalWO
+  public PageResultResource<DetectedForbiddenCommandDTO> findAllForbiddenCommandsOfDetectionEvent(
+      Long eventId, Pageable pageable) {
+    return detectedForbiddenCommandMapper.mapToPageResultResource(
+        this.detectionEventService.findAllForbiddenCommandsOfDetectionEvent(eventId, pageable));
+  }
 
-    /**
-     * Finds all forbidden commands of detection event for visualization.
-     *
-     * @param eventId the detection event ID
-     */
-    @PreAuthorize("hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)")
-    @TransactionalWO
-    public List<DetectedForbiddenCommandDTO> findAllForbiddenCommandsOfDetectionEvent(Long eventId) {
-        return detectedForbiddenCommandMapper.mapToListDTO(this.detectionEventService.findAllForbiddenCommandsOfDetectionEvent(eventId));
-    }
+  /**
+   * Finds all forbidden commands of detection event for visualization.
+   *
+   * @param eventId the detection event ID
+   */
+  @PreAuthorize(
+      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)")
+  @TransactionalWO
+  public List<DetectedForbiddenCommandDTO> findAllForbiddenCommandsOfDetectionEvent(Long eventId) {
+    return detectedForbiddenCommandMapper.mapToListDTO(
+        this.detectionEventService.findAllForbiddenCommandsOfDetectionEvent(eventId));
+  }
 
-    /**
-     * Find detection event by its ID.
-     *
-     * @param eventId the detection event ID
-     */
-    @PreAuthorize("hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)")
-    @TransactionalWO
-    public AbstractDetectionEventDTO findDetectionEventById(Long eventId) {
-        return detectionEventMapper.mapToDTO(this.detectionEventService.findDetectionEventById(eventId));
-    }
+  /**
+   * Find detection event by its ID.
+   *
+   * @param eventId the detection event ID
+   */
+  @PreAuthorize(
+      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)")
+  @TransactionalWO
+  public AbstractDetectionEventDTO findDetectionEventById(Long eventId) {
+    return detectionEventMapper.mapToDTO(
+        this.detectionEventService.findDetectionEventById(eventId));
+  }
 
-    /**
-     * Find detection event of type answer similarity by its ID.
-     *
-     * @param eventId the detection event ID
-     */
-    @PreAuthorize("hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)")
-    @TransactionalWO
-    public AnswerSimilarityDetectionEventDTO findAnswerSimilarityEventById(Long eventId) {
-        return detectionEventMapper.mapToAnswerSimilarityDetectionEventDTO(this.answerSimilarityService.findAnswerSimilarityEventById(eventId));
-    }
+  /**
+   * Find detection event of type answer similarity by its ID.
+   *
+   * @param eventId the detection event ID
+   */
+  @PreAuthorize(
+      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)")
+  @TransactionalWO
+  public AnswerSimilarityDetectionEventDTO findAnswerSimilarityEventById(Long eventId) {
+    return detectionEventMapper.mapToAnswerSimilarityDetectionEventDTO(
+        this.answerSimilarityService.findAnswerSimilarityEventById(eventId));
+  }
 
-    /**
-     * Find detection event of type location similarity by its ID.
-     *
-     * @param eventId the detection event ID
-     */
-    @PreAuthorize("hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)")
-    @TransactionalWO
-    public LocationSimilarityDetectionEventDTO findLocationSimilarityEventById(Long eventId) {
-        return detectionEventMapper.mapToLocationSimilarityDetectionEventDTO(this.locationSimilarityService.findLocationSimilarityEventById(eventId));
-    }
+  /**
+   * Find detection event of type location similarity by its ID.
+   *
+   * @param eventId the detection event ID
+   */
+  @PreAuthorize(
+      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)")
+  @TransactionalWO
+  public LocationSimilarityDetectionEventDTO findLocationSimilarityEventById(Long eventId) {
+    return detectionEventMapper.mapToLocationSimilarityDetectionEventDTO(
+        this.locationSimilarityService.findLocationSimilarityEventById(eventId));
+  }
 
-    /**
-     * Find detection event of type time proximity by its ID.
-     *
-     * @param eventId the detection event ID
-     */
-    @PreAuthorize("hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)")
-    @TransactionalWO
-    public TimeProximityDetectionEventDTO findTimeProximityEventById(Long eventId) {
-        return detectionEventMapper.mapToTimeProximityDetectionEventDTO(this.timeProximityService.findTimeProximityEventById(eventId));
-    }
+  /**
+   * Find detection event of type time proximity by its ID.
+   *
+   * @param eventId the detection event ID
+   */
+  @PreAuthorize(
+      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)")
+  @TransactionalWO
+  public TimeProximityDetectionEventDTO findTimeProximityEventById(Long eventId) {
+    return detectionEventMapper.mapToTimeProximityDetectionEventDTO(
+        this.timeProximityService.findTimeProximityEventById(eventId));
+  }
 
-    /**
-     * Find detection event of type minimal solve time by its ID.
-     *
-     * @param eventId the detection event ID
-     */
-    @PreAuthorize("hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)")
-    @TransactionalWO
-    public MinimalSolveTimeDetectionEventDTO findMinimalSolveTimeEventById(Long eventId) {
-        return detectionEventMapper.mapToMinimalSolveTimeDetectionEventDTO(this.minimalSolveTimeService.findMinimalSolveTimeEventById(eventId));
-    }
+  /**
+   * Find detection event of type minimal solve time by its ID.
+   *
+   * @param eventId the detection event ID
+   */
+  @PreAuthorize(
+      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)")
+  @TransactionalWO
+  public MinimalSolveTimeDetectionEventDTO findMinimalSolveTimeEventById(Long eventId) {
+    return detectionEventMapper.mapToMinimalSolveTimeDetectionEventDTO(
+        this.minimalSolveTimeService.findMinimalSolveTimeEventById(eventId));
+  }
 
-    /**
-     * Find detection event of type no commands by its ID.
-     *
-     * @param eventId the detection event ID
-     */
-    @PreAuthorize("hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)")
-    @TransactionalWO
-    public NoCommandsDetectionEventDTO findNoCommandsEventById(Long eventId) {
-        return detectionEventMapper.mapToNoCommandsDetectionEventDTO(this.noCommandsService.findNoCommandsEventById(eventId));
-    }
+  /**
+   * Find detection event of type no commands by its ID.
+   *
+   * @param eventId the detection event ID
+   */
+  @PreAuthorize(
+      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)")
+  @TransactionalWO
+  public NoCommandsDetectionEventDTO findNoCommandsEventById(Long eventId) {
+    return detectionEventMapper.mapToNoCommandsDetectionEventDTO(
+        this.noCommandsService.findNoCommandsEventById(eventId));
+  }
 
-    /**
-     * Find detection event of type forbidden commands by its ID.
-     *
-     * @param eventId the detection event ID
-     */
-    @PreAuthorize("hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)")
-    @TransactionalWO
-    public ForbiddenCommandsDetectionEventDTO findForbiddenCommandsEventById(Long eventId) {
-        return detectionEventMapper.mapToForbiddenCommandsDetectionEventDTO(this.forbiddenCommandsService.findForbiddenCommandsEventById(eventId));
-    }
+  /**
+   * Find detection event of type forbidden commands by its ID.
+   *
+   * @param eventId the detection event ID
+   */
+  @PreAuthorize(
+      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)")
+  @TransactionalWO
+  public ForbiddenCommandsDetectionEventDTO findForbiddenCommandsEventById(Long eventId) {
+    return detectionEventMapper.mapToForbiddenCommandsDetectionEventDTO(
+        this.forbiddenCommandsService.findForbiddenCommandsEventById(eventId));
+  }
 }

--- a/training-service/src/main/java/cz/cyberrange/platform/training/service/services/api/AnswersStorageApiService.java
+++ b/training-service/src/main/java/cz/cyberrange/platform/training/service/services/api/AnswersStorageApiService.java
@@ -4,162 +4,205 @@ import cz.cyberrange.platform.training.api.exceptions.CustomWebClientException;
 import cz.cyberrange.platform.training.api.exceptions.MicroserviceApiException;
 import cz.cyberrange.platform.training.api.responses.PageResultResource;
 import cz.cyberrange.platform.training.api.responses.SandboxAnswersInfo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.List;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import java.util.List;
-
-/**
- * The type Answers Storage Api Service.
- */
+/** The type Answers Storage Api Service. */
 @Service
 public class AnswersStorageApiService {
 
-    private static final Logger LOG = LoggerFactory.getLogger(AnswersStorageApiService.class);
-    private final WebClient answersStorageWebClient;
+  private final WebClient answersStorageWebClient;
 
-    /**
-     * Instantiates a new AnswersStorageApi service.
-     *
-     * @param answersStorageWebClient the web client
-     */
-    public AnswersStorageApiService(WebClient answersStorageWebClient) {
-        this.answersStorageWebClient = answersStorageWebClient;
+  /**
+   * Instantiates a new AnswersStorageApi service.
+   *
+   * @param answersStorageWebClient the web client
+   */
+  public AnswersStorageApiService(WebClient answersStorageWebClient) {
+    this.answersStorageWebClient = answersStorageWebClient;
+  }
+
+  /**
+   * Get correct answer for the given cloud sandbox and with specific answer identifier.
+   *
+   * @param sandboxId id of the sandbox used by trainee.
+   * @param answerVariableName identifier of the answer.
+   * @throws MicroserviceApiException error with specific message when calling answer storage
+   *     microservice.
+   */
+  public String getCorrectAnswerByCloudSandboxIdAndVariableName(
+      String sandboxId, String answerVariableName) {
+    try {
+      return answersStorageWebClient
+          .get()
+          .uri("/sandboxes/{sandboxId}/answers/{answerVariableName}", sandboxId, answerVariableName)
+          .retrieve()
+          .bodyToMono(String.class)
+          .block();
+    } catch (CustomWebClientException ex) {
+      throw new MicroserviceApiException(
+          "Error when calling Answers Storage API to get correct answer (Identifier: "
+              + answerVariableName
+              + ") for sandbox (ID: "
+              + sandboxId
+              + ").",
+          ex);
     }
+  }
 
-    /**
-     * Get correct answer for the given cloud sandbox and with specific answer identifier.
-     *
-     * @param sandboxId id of the sandbox used by trainee.
-     * @param answerVariableName identifier of the answer.
-     * @throws MicroserviceApiException error with specific message when calling answer storage microservice.
-     */
-    public String getCorrectAnswerByCloudSandboxIdAndVariableName(String sandboxId, String answerVariableName){
-        try {
-            return answersStorageWebClient
-                    .get()
-                    .uri("/sandboxes/{sandboxId}/answers/{answerVariableName}", sandboxId, answerVariableName)
-                    .retrieve()
-                    .bodyToMono(String.class)
-                    .block();
-        } catch (CustomWebClientException ex){
-            throw new MicroserviceApiException("Error when calling Answers Storage API to get correct answer (Identifier: "+ answerVariableName +") for sandbox (ID: " + sandboxId + ").", ex);
-        }
+  /**
+   * Get correct answer for the given local sandbox and with specific answer identifier.
+   *
+   * @param accessToken access token of the training instance.
+   * @param userId id of the user who owns the local sandbox.
+   * @param answerVariableName identifier of the answer.
+   * @throws MicroserviceApiException error with specific message when calling answer storage
+   *     microservice.
+   */
+  public String getCorrectAnswerByLocalSandboxIdAndVariableName(
+      String accessToken, Long userId, String answerVariableName) {
+    try {
+      return answersStorageWebClient
+          .get()
+          .uri(
+              "/sandboxes/access-tokens/{accessToken}/users/{userId}/answers/{answerVariableName}",
+              accessToken,
+              userId,
+              answerVariableName)
+          .retrieve()
+          .bodyToMono(String.class)
+          .block();
+    } catch (CustomWebClientException ex) {
+      throw new MicroserviceApiException(
+          "Error when calling Answers Storage API to get correct answer (Identifier: "
+              + answerVariableName
+              + ") "
+              + "for sandbox (Access Token: "
+              + accessToken
+              + ", User ID: "
+              + userId
+              + ").",
+          ex);
     }
+  }
 
-    /**
-     * Get correct answer for the given local sandbox and with specific answer identifier.
-     *
-     * @param accessToken access token of the training instance.
-     * @param userId id of the user who owns the local sandbox.
-     * @param answerVariableName identifier of the answer.
-     * @throws MicroserviceApiException error with specific message when calling answer storage microservice.
-     */
-    public String getCorrectAnswerByLocalSandboxIdAndVariableName(String accessToken, Long userId, String answerVariableName){
-        try {
-            return answersStorageWebClient
-                    .get()
-                    .uri("/sandboxes/access-tokens/{accessToken}/users/{userId}/answers/{answerVariableName}", accessToken, userId, answerVariableName)
-                    .retrieve()
-                    .bodyToMono(String.class)
-                    .block();
-        } catch (CustomWebClientException ex){
-            throw new MicroserviceApiException("Error when calling Answers Storage API to get correct answer (Identifier: "+ answerVariableName +") " +
-                    "for sandbox (Access Token: " + accessToken + ", User ID: " + userId + ").", ex);
-        }
+  /**
+   * Get all answers generated for the given cloud sandbox.
+   *
+   * @param sandboxId id of the sandbox.
+   * @throws MicroserviceApiException error with specific message when calling answer storage
+   *     microservice.
+   */
+  public SandboxAnswersInfo getAnswersBySandboxId(String sandboxId) {
+    try {
+      return answersStorageWebClient
+          .get()
+          .uri("/sandboxes/{sandboxId}/answers", sandboxId)
+          .retrieve()
+          .bodyToMono(SandboxAnswersInfo.class)
+          .block();
+    } catch (CustomWebClientException ex) {
+      throw new MicroserviceApiException(
+          "Error when calling Answers Storage API to get correct answers for cloud sandbox (ID: "
+              + sandboxId
+              + ").",
+          ex);
     }
+  }
 
-
-    /**
-     * Get all answers generated for the given cloud sandbox.
-     *
-     * @param sandboxId id of the sandbox.
-     * @throws MicroserviceApiException error with specific message when calling answer storage microservice.
-     */
-    public SandboxAnswersInfo getAnswersBySandboxId(String sandboxId) {
-        try {
-            return answersStorageWebClient
-                    .get()
-                    .uri("/sandboxes/{sandboxId}/answers", sandboxId)
-                    .retrieve()
-                    .bodyToMono(SandboxAnswersInfo.class)
-                    .block();
-        } catch (CustomWebClientException ex){
-            throw new MicroserviceApiException("Error when calling Answers Storage API to get correct answers for cloud sandbox (ID: " + sandboxId + ").", ex);
-        }
+  /**
+   * Get all answers generated for the given local sandbox.
+   *
+   * @param accessToken access token of the training instance.
+   * @param userId id of the user.
+   * @throws MicroserviceApiException error with specific message when calling answer storage
+   *     microservice.
+   */
+  public SandboxAnswersInfo getAnswersByAccessTokenAndUserId(String accessToken, Long userId) {
+    try {
+      return answersStorageWebClient
+          .get()
+          .uri("/sandboxes/access-tokens/{accessToken}/users/{userId}", accessToken, userId)
+          .retrieve()
+          .bodyToMono(SandboxAnswersInfo.class)
+          .block();
+    } catch (CustomWebClientException ex) {
+      throw new MicroserviceApiException(
+          "Error when calling Answers Storage API to get correct answers for local sandbox (accessToken: "
+              + accessToken
+              + ", userID: "
+              + userId
+              + ").",
+          ex);
     }
+  }
 
-    /**
-     * Get all answers generated for the given local sandbox.
-     *
-     * @param accessToken access token of the training instance.
-     * @param userId id of the user.
-     * @throws MicroserviceApiException error with specific message when calling answer storage microservice.
-     */
-    public SandboxAnswersInfo getAnswersByAccessTokenAndUserId(String accessToken, Long userId) {
-        try {
-            return answersStorageWebClient
-                    .get()
-                    .uri("/sandboxes/access-tokens/{accessToken}/users/{userId}", accessToken, userId)
-                    .retrieve()
-                    .bodyToMono(SandboxAnswersInfo.class)
-                    .block();
-        } catch (CustomWebClientException ex){
-            throw new MicroserviceApiException("Error when calling Answers Storage API to get correct answers for local sandbox (accessToken: " + accessToken + ", userID: " + userId + ").", ex);
-        }
+  /**
+   * Get all answers generated for the given cloud sandboxes.
+   *
+   * @param sandboxIds ids of the sandboxes.
+   * @throws MicroserviceApiException error with specific message when calling answers storage
+   *     microservice.
+   */
+  public PageResultResource<SandboxAnswersInfo> getAnswersBySandboxIds(List<String> sandboxIds) {
+    try {
+      return answersStorageWebClient
+          .get()
+          .uri(
+              uriBuilder ->
+                  uriBuilder
+                      .path("/sandboxes")
+                      .queryParam("sandboxRefId", sandboxIds)
+                      .queryParam("page", 0)
+                      .queryParam("size", Integer.MAX_VALUE)
+                      .build())
+          .retrieve()
+          .bodyToMono(new ParameterizedTypeReference<PageResultResource<SandboxAnswersInfo>>() {})
+          .block();
+    } catch (CustomWebClientException ex) {
+      throw new MicroserviceApiException(
+          "Error when calling Answers Storage API to get correct answers for sandboxes (IDs: "
+              + sandboxIds
+              + ").",
+          ex);
     }
+  }
 
-    /**
-     * Get all answers generated for the given cloud sandboxes.
-     *
-     * @param sandboxIds ids of the sandboxes.
-     * @throws MicroserviceApiException error with specific message when calling answers storage microservice.
-     */
-    public PageResultResource<SandboxAnswersInfo> getAnswersBySandboxIds(List<String> sandboxIds) {
-        try {
-            return answersStorageWebClient
-                    .get()
-                    .uri(uriBuilder -> uriBuilder
-                            .path("/sandboxes")
-                            .queryParam("sandboxRefId", sandboxIds)
-                            .queryParam("page", 0)
-                            .queryParam("size", Integer.MAX_VALUE)
-                            .build())
-                    .retrieve()
-                    .bodyToMono(new ParameterizedTypeReference<PageResultResource<SandboxAnswersInfo>>() {})
-                    .block();
-        } catch (CustomWebClientException ex){
-            throw new MicroserviceApiException("Error when calling Answers Storage API to get correct answers for sandboxes (IDs: " + sandboxIds + ").", ex);
-        }
+  /**
+   * Get all answers generated for the local sandboxes by the users IDs and specific access token.
+   *
+   * @param accessToken token of the training instance
+   * @param userIds ids of the users.
+   * @throws MicroserviceApiException error with specific message when calling answers storage
+   *     microservice.
+   */
+  public PageResultResource<SandboxAnswersInfo> getAnswersByAccessTokenAndUserIds(
+      String accessToken, List<Long> userIds) {
+    try {
+      return answersStorageWebClient
+          .get()
+          .uri(
+              uriBuilder ->
+                  uriBuilder
+                      .path("/sandboxes")
+                      .queryParam("accessToken", accessToken)
+                      .queryParam("userId", userIds)
+                      .queryParam("page", 0)
+                      .queryParam("size", Integer.MAX_VALUE)
+                      .build())
+          .retrieve()
+          .bodyToMono(new ParameterizedTypeReference<PageResultResource<SandboxAnswersInfo>>() {})
+          .block();
+    } catch (CustomWebClientException ex) {
+      throw new MicroserviceApiException(
+          "Error when calling Answers Storage API to get correct answers for local sandboxes (accessToken: "
+              + accessToken
+              + ", userIDs: "
+              + userIds
+              + ").",
+          ex);
     }
-
-    /**
-     * Get all answers generated for the local sandboxes by the users IDs and specific access token.
-     *
-     * @param accessToken token of the training instance
-     * @param userIds ids of the users.
-     * @throws MicroserviceApiException error with specific message when calling answers storage microservice.
-     */
-    public PageResultResource<SandboxAnswersInfo> getAnswersByAccessTokenAndUserIds(String accessToken, List<Long> userIds) {
-        try {
-            return answersStorageWebClient
-                    .get()
-                    .uri(uriBuilder -> uriBuilder
-                            .path("/sandboxes")
-                            .queryParam("accessToken", accessToken)
-                            .queryParam("userId", userIds)
-                            .queryParam("page", 0)
-                            .queryParam("size", Integer.MAX_VALUE)
-                            .build())
-                    .retrieve()
-                    .bodyToMono(new ParameterizedTypeReference<PageResultResource<SandboxAnswersInfo>>() {})
-                    .block();
-        } catch (CustomWebClientException ex){
-            throw new MicroserviceApiException("Error when calling Answers Storage API to get correct answers for local sandboxes (accessToken: " + accessToken + ", userIDs: " + userIds + ").", ex);
-        }
-    }
+  }
 }
-


### PR DESCRIPTION
Ensured `callSuper` is added to EqualsAndHashCode on DTOs for predictable behaviour. This ensures that DTOs, which are primarily structurally compared, will check all fields on equals comparison.