### PR TITLE
Update permissions to not block legitimate calls

### DIFF
--- a/etc/ci_settings.xml
+++ b/etc/ci_settings.xml
@@ -5,7 +5,7 @@
         <profile>
             <id>inject-version-variable</id>
             <properties>
-                <app-version>2.0.1</app-version>
+                <app-version>2.1.0</app-version>
             </properties>
         </profile>
     </profiles>

--- a/training-service/src/main/java/cz/cyberrange/platform/training/service/facade/TrainingDefinitionFacade.java
+++ b/training-service/src/main/java/cz/cyberrange/platform/training/service/facade/TrainingDefinitionFacade.java
@@ -44,7 +44,7 @@ import cz.cyberrange.platform.training.persistence.repository.TrainingDefinition
 import cz.cyberrange.platform.training.service.annotations.security.IsDesignerOrAdmin;
 import cz.cyberrange.platform.training.service.annotations.security.IsDesignerOrOrganizerOrAdmin;
 import cz.cyberrange.platform.training.service.annotations.security.IsOrganizerOrAdmin;
-import cz.cyberrange.platform.training.service.annotations.security.IsTrainee;
+import cz.cyberrange.platform.training.service.annotations.security.IsTraineeOrAdmin;
 import cz.cyberrange.platform.training.service.annotations.transactions.TransactionalRO;
 import cz.cyberrange.platform.training.service.annotations.transactions.TransactionalWO;
 import cz.cyberrange.platform.training.service.enums.RoleTypeSecurity;
@@ -198,7 +198,7 @@ public class TrainingDefinitionFacade {
    *
    * @return the {@link TrainingDefinitionMitreTechniquesDTO} of definitions using MITRE techniques
    */
-  @IsTrainee
+  @IsTraineeOrAdmin
   @TransactionalRO
   public List<TrainingDefinitionMitreTechniquesDTO> findPlayedMitreTechniques() {
     Set<Long> playedDefinitionIds =

--- a/training-service/src/main/java/cz/cyberrange/platform/training/service/facade/TrainingDefinitionFacade.java
+++ b/training-service/src/main/java/cz/cyberrange/platform/training/service/facade/TrainingDefinitionFacade.java
@@ -119,7 +119,8 @@ public class TrainingDefinitionFacade {
    */
   @PreAuthorize(
       "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)"
-          + "or @securityService.isDesignerOfGivenTrainingDefinition(#id)")
+          + "or @securityService.isDesignerOfGivenTrainingDefinition(#id)"
+          + "or @securityService.isOrganizerForGivenTrainingDefinition(#id)")
   @TransactionalRO
   public TrainingDefinitionWithLevelsDTO findById(Long id) {
     TrainingDefinition trainingDefinition = trainingDefinitionService.findById(id);

--- a/training-service/src/main/java/cz/cyberrange/platform/training/service/facade/TrainingRunFacade.java
+++ b/training-service/src/main/java/cz/cyberrange/platform/training/service/facade/TrainingRunFacade.java
@@ -492,7 +492,9 @@ public class TrainingRunFacade {
    * @param trainingRunId id of Training Run to be finish.
    * @param responsesToQuestions responses to assessment
    */
-  @IsTrainee
+  @PreAuthorize(
+      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)"
+          + "or @securityService.isTraineeOfGivenTrainingRun(#trainingRunId)")
   @TransactionalWO
   public void evaluateResponsesToAssessment(
       Long trainingRunId, List<QuestionAnswerDTO> responsesToQuestions) {

--- a/training-service/src/main/java/cz/cyberrange/platform/training/service/facade/detection/CheatingDetectionExportFacade.java
+++ b/training-service/src/main/java/cz/cyberrange/platform/training/service/facade/detection/CheatingDetectionExportFacade.java
@@ -56,7 +56,8 @@ public class CheatingDetectionExportFacade {
    * @return the file containing cheating detection, {@link FileToReturnDTO}
    */
   @PreAuthorize(
-      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)")
+      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)"
+          + "or @securityService.isOrganizerOfGivenCheatingDetection(#cheatingDetectionId)")
   @TransactionalRO
   public FileToReturnDTO archiveCheatingDetectionResults(Long cheatingDetectionId) {
     try (ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/training-service/src/main/java/cz/cyberrange/platform/training/service/facade/detection/CheatingDetectionFacade.java
+++ b/training-service/src/main/java/cz/cyberrange/platform/training/service/facade/detection/CheatingDetectionFacade.java
@@ -67,7 +67,7 @@ public class CheatingDetectionFacade {
    */
   @PreAuthorize(
       "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)"
-          + "or @securityService.isOrganizerOfGivenTrainingInstance(#trainingInstanceId)")
+          + "or @securityService.isOrganizerOfGivenCheatingDetection(#cheatingDetectionId)")
   @TransactionalWO
   public void rerunCheatingDetection(Long cheatingDetectionId, Long trainingInstanceId) {
     this.detectionEventService.deleteDetectionEvents(cheatingDetectionId);
@@ -82,7 +82,8 @@ public class CheatingDetectionFacade {
    */
   @PreAuthorize(
       "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)"
-          + "or @securityService.isOrganizerOfGivenTrainingInstance(#trainingInstanceId)")
+          + "or (@securityService.isOrganizerOfGivenCheatingDetection(#cheatingDetectionId)"
+          + " and @securityService.isOrganizerOfGivenTrainingInstance(#trainingInstanceId))")
   @TransactionalWO
   public void deleteCheatingDetection(Long cheatingDetectionId, Long trainingInstanceId) {
     this.cheatingDetectionService.deleteCheatingDetection(cheatingDetectionId, trainingInstanceId);

--- a/training-service/src/main/java/cz/cyberrange/platform/training/service/facade/detection/DetectionEventFacade.java
+++ b/training-service/src/main/java/cz/cyberrange/platform/training/service/facade/detection/DetectionEventFacade.java
@@ -95,7 +95,7 @@ public class DetectionEventFacade {
    */
   @PreAuthorize(
       "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)"
-          + "or @securityService.isOrganizerOfGivenTrainingInstance(#trainingInstanceId)")
+          + "or @securityService.isOrganizerOfGivenCheatingDetection(#cheatingDetectionId)")
   @TransactionalWO
   public PageResultResource<AbstractDetectionEventDTO> findAllDetectionEventsOfCheatingDetection(
       Long cheatingDetectionId, Pageable pageable, Predicate predicate, Long trainingInstanceId) {
@@ -111,7 +111,8 @@ public class DetectionEventFacade {
    * @param pageable the pageable
    */
   @PreAuthorize(
-      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)")
+      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)"
+          + "or @securityService.isOrganizerOfGivenDetectionEvent(#eventId)")
   @TransactionalWO
   public PageResultResource<DetectionEventParticipantDTO> findAllParticipantsOfDetectionEvent(
       Long eventId, Pageable pageable) {
@@ -126,7 +127,8 @@ public class DetectionEventFacade {
    * @param pageable the pageable
    */
   @PreAuthorize(
-      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)")
+      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)"
+          + "or @securityService.isOrganizerOfGivenDetectionEvent(#eventId)")
   @TransactionalWO
   public PageResultResource<DetectedForbiddenCommandDTO> findAllForbiddenCommandsOfDetectionEvent(
       Long eventId, Pageable pageable) {
@@ -140,7 +142,8 @@ public class DetectionEventFacade {
    * @param eventId the detection event ID
    */
   @PreAuthorize(
-      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)")
+      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)"
+          + "or @securityService.isOrganizerOfGivenDetectionEvent(#eventId)")
   @TransactionalWO
   public List<DetectedForbiddenCommandDTO> findAllForbiddenCommandsOfDetectionEvent(Long eventId) {
     return detectedForbiddenCommandMapper.mapToListDTO(
@@ -153,7 +156,8 @@ public class DetectionEventFacade {
    * @param eventId the detection event ID
    */
   @PreAuthorize(
-      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)")
+      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)"
+          + "or @securityService.isOrganizerOfGivenDetectionEvent(#eventId)")
   @TransactionalWO
   public AbstractDetectionEventDTO findDetectionEventById(Long eventId) {
     return detectionEventMapper.mapToDTO(
@@ -166,7 +170,8 @@ public class DetectionEventFacade {
    * @param eventId the detection event ID
    */
   @PreAuthorize(
-      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)")
+      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)"
+          + "or @securityService.isOrganizerOfGivenDetectionEvent(#eventId)")
   @TransactionalWO
   public AnswerSimilarityDetectionEventDTO findAnswerSimilarityEventById(Long eventId) {
     return detectionEventMapper.mapToAnswerSimilarityDetectionEventDTO(
@@ -179,7 +184,8 @@ public class DetectionEventFacade {
    * @param eventId the detection event ID
    */
   @PreAuthorize(
-      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)")
+      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)"
+          + "or @securityService.isOrganizerOfGivenDetectionEvent(#eventId)")
   @TransactionalWO
   public LocationSimilarityDetectionEventDTO findLocationSimilarityEventById(Long eventId) {
     return detectionEventMapper.mapToLocationSimilarityDetectionEventDTO(
@@ -192,7 +198,8 @@ public class DetectionEventFacade {
    * @param eventId the detection event ID
    */
   @PreAuthorize(
-      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)")
+      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)"
+          + "or @securityService.isOrganizerOfGivenDetectionEvent(#eventId)")
   @TransactionalWO
   public TimeProximityDetectionEventDTO findTimeProximityEventById(Long eventId) {
     return detectionEventMapper.mapToTimeProximityDetectionEventDTO(
@@ -205,7 +212,8 @@ public class DetectionEventFacade {
    * @param eventId the detection event ID
    */
   @PreAuthorize(
-      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)")
+      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)"
+          + "or @securityService.isOrganizerOfGivenDetectionEvent(#eventId)")
   @TransactionalWO
   public MinimalSolveTimeDetectionEventDTO findMinimalSolveTimeEventById(Long eventId) {
     return detectionEventMapper.mapToMinimalSolveTimeDetectionEventDTO(
@@ -218,7 +226,8 @@ public class DetectionEventFacade {
    * @param eventId the detection event ID
    */
   @PreAuthorize(
-      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)")
+      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)"
+          + "or @securityService.isOrganizerOfGivenDetectionEvent(#eventId)")
   @TransactionalWO
   public NoCommandsDetectionEventDTO findNoCommandsEventById(Long eventId) {
     return detectionEventMapper.mapToNoCommandsDetectionEventDTO(
@@ -231,7 +240,8 @@ public class DetectionEventFacade {
    * @param eventId the detection event ID
    */
   @PreAuthorize(
-      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)")
+      "hasAuthority(T(cz.cyberrange.platform.training.service.enums.RoleTypeSecurity).ROLE_TRAINING_ADMINISTRATOR)"
+          + "or @securityService.isOrganizerOfGivenDetectionEvent(#eventId)")
   @TransactionalWO
   public ForbiddenCommandsDetectionEventDTO findForbiddenCommandsEventById(Long eventId) {
     return detectionEventMapper.mapToForbiddenCommandsDetectionEventDTO(

--- a/training-service/src/main/java/cz/cyberrange/platform/training/service/services/SecurityService.java
+++ b/training-service/src/main/java/cz/cyberrange/platform/training/service/services/SecurityService.java
@@ -11,12 +11,16 @@ import cz.cyberrange.platform.training.persistence.model.TrainingDefinition;
 import cz.cyberrange.platform.training.persistence.model.TrainingInstance;
 import cz.cyberrange.platform.training.persistence.model.TrainingRun;
 import cz.cyberrange.platform.training.persistence.model.UserRef;
+import cz.cyberrange.platform.training.persistence.model.detection.AbstractDetectionEvent;
+import cz.cyberrange.platform.training.persistence.model.detection.CheatingDetection;
 import cz.cyberrange.platform.training.persistence.repository.AbstractLevelRepository;
 import cz.cyberrange.platform.training.persistence.repository.HintRepository;
 import cz.cyberrange.platform.training.persistence.repository.TrainingDefinitionRepository;
 import cz.cyberrange.platform.training.persistence.repository.TrainingInstanceRepository;
 import cz.cyberrange.platform.training.persistence.repository.TrainingLevelRepository;
 import cz.cyberrange.platform.training.persistence.repository.TrainingRunRepository;
+import cz.cyberrange.platform.training.persistence.repository.detection.AbstractDetectionEventRepository;
+import cz.cyberrange.platform.training.persistence.repository.detection.CheatingDetectionRepository;
 import cz.cyberrange.platform.training.service.annotations.transactions.TransactionalRO;
 import cz.cyberrange.platform.training.service.enums.RoleTypeSecurity;
 import java.util.List;
@@ -44,6 +48,8 @@ public class SecurityService {
   private final AbstractLevelRepository abstractLevelRepository;
   private final TrainingLevelRepository trainingLevelRepository;
   private final HintRepository hintRepository;
+  private final AbstractDetectionEventRepository abstractDetectionEventRepository;
+  private final CheatingDetectionRepository cheatingDetectionRepository;
 
   /**
    * Instantiates a new Security service.
@@ -52,6 +58,8 @@ public class SecurityService {
    * @param trainingDefinitionRepository the training definition repository
    * @param trainingRunRepository the training run repository
    * @param userManagementWebClient the java rest template
+   * @param abstractDetectionEventRepository the abstract detection event repository
+   * @param cheatingDetectionRepository the cheating detection repository
    */
   @Autowired
   public SecurityService(
@@ -62,7 +70,9 @@ public class SecurityService {
       UserService userService,
       AbstractLevelRepository abstractLevelRepository,
       TrainingLevelRepository trainingLevelRepository,
-      HintRepository hintRepository) {
+      HintRepository hintRepository,
+      AbstractDetectionEventRepository abstractDetectionEventRepository,
+      CheatingDetectionRepository cheatingDetectionRepository) {
     this.trainingDefinitionRepository = trainingDefinitionRepository;
     this.trainingInstanceRepository = trainingInstanceRepository;
     this.trainingRunRepository = trainingRunRepository;
@@ -71,6 +81,8 @@ public class SecurityService {
     this.abstractLevelRepository = abstractLevelRepository;
     this.trainingLevelRepository = trainingLevelRepository;
     this.hintRepository = hintRepository;
+    this.abstractDetectionEventRepository = abstractDetectionEventRepository;
+    this.cheatingDetectionRepository = cheatingDetectionRepository;
   }
 
   /**
@@ -138,6 +150,52 @@ public class SecurityService {
                             "The necessary permissions are required for a resource.")));
     return trainingRun.getTrainingInstance().getOrganizers().stream()
         .anyMatch(o -> o.getUserRefId().equals(getUserRefIdFromUserAndGroup()));
+  }
+
+  /**
+   * Is organizer of given detection event.
+   *
+   * @param eventId the detection event id
+   * @return the boolean
+   * @throws EntityNotFoundException when the detection event with the given id does not exist
+   */
+  public boolean isOrganizerOfGivenDetectionEvent(Long eventId) {
+    AbstractDetectionEvent detectionEvent =
+        abstractDetectionEventRepository
+            .findById(eventId)
+            .orElseThrow(
+                () ->
+                    new EntityNotFoundException(
+                        new EntityErrorDetail(
+                            AbstractDetectionEvent.class,
+                            "id",
+                            eventId.getClass(),
+                            eventId,
+                            "The necessary permissions are required for a resource.")));
+    return isOrganizerOfGivenTrainingInstance(detectionEvent.getTrainingInstanceId());
+  }
+
+  /**
+   * Is organizer of given cheating detection.
+   *
+   * @param cheatingDetectionId the cheating detection id
+   * @return the boolean
+   * @throws EntityNotFoundException when the cheating detection with the given id does not exist
+   */
+  public boolean isOrganizerOfGivenCheatingDetection(Long cheatingDetectionId) {
+    CheatingDetection cheatingDetection =
+        cheatingDetectionRepository
+            .findById(cheatingDetectionId)
+            .orElseThrow(
+                () ->
+                    new EntityNotFoundException(
+                        new EntityErrorDetail(
+                            CheatingDetection.class,
+                            "id",
+                            cheatingDetectionId.getClass(),
+                            cheatingDetectionId,
+                            "The necessary permissions are required for a resource.")));
+    return isOrganizerOfGivenTrainingInstance(cheatingDetection.getTrainingInstanceId());
   }
 
   /**


### PR DESCRIPTION
Organiser 
  - can now view definition he organises in a training instance
  - can now manage cheating detections on his own training instances
 
 Trainee
   - can no longer submit assessment answers for run he does not own

Admin
  - can now access all endpoints correctly